### PR TITLE
content entity configuration

### DIFF
--- a/usagov_bears/README.md
+++ b/usagov_bears/README.md
@@ -20,10 +20,22 @@ This module provides custom block "usagov bears block" with div id="usagov-bears
 
 ## USAgov bears content module
 
+config/optional folder include configuration of content type, taxonomy, paragraph...
+
+```
+bin/drush config:import \
+  --partial \
+  --source=modules/custom/usagov_bears/modules/usagov_bears_content/config/optional
+```
+This imports the configuration of content type, taxonomy, paragraph, custom entity.
+
+
 config folder includes content type, taxonomy, paragraph, custom entity configuration.
 
 ```
-bin/drush config:import --partial --source=modules/custom/usagov_bears/modules/usagov_bears_content/config
+bin/drush config:import \
+  --partial \
+  --source=modules/custom/usagov_bears/modules/usagov_bears_content/config
 ```
 This imports the configuration of content type, taxonomy, paragraph, custom entity.
 

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.base_field_override.node.bears_agency.title.yml.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.base_field_override.node.bears_agency.title.yml.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.bears_agency
+id: node.bears_agency.title
+field_name: title
+entity_type: node
+bundle: bears_agency
+label: Title
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.base_field_override.node.bears_benefit.title.yml.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.base_field_override.node.bears_benefit.title.yml.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.bears_benefit
+id: node.bears_benefit.title
+field_name: title
+entity_type: node
+bundle: bears_benefit
+label: Title
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.base_field_override.node.bears_life_event.title.yml.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.base_field_override.node.bears_life_event.title.yml.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.bears_life_event
+id: node.bears_life_event.title
+field_name: title
+entity_type: node
+bundle: bears_life_event
+label: Title
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.node.bears_agency.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.node.bears_agency.default.yml
@@ -1,0 +1,116 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.bears_agency.field_b_lede
+    - field.field.node.bears_agency.field_b_summary
+    - field.field.node.bears_agency.field_b_title
+    - node.type.bears_agency
+  module:
+    - content_moderation
+    - path
+    - text
+id: node.bears_agency.default
+targetEntityType: node
+bundle: bears_agency
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_b_lede:
+    type: text_textarea
+    weight: 11
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_summary:
+    type: text_textarea
+    weight: 10
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_title:
+    type: string_textfield
+    weight: 7
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 0
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 9
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    weight: 3
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 6
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 4
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 12
+    region: content
+    settings:
+      size: 60
+      placeholder: HELLO
+    third_party_settings: {  }
+  translation:
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 8
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.node.bears_benefit.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.node.bears_benefit.default.yml
@@ -1,0 +1,178 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.bears_benefit.field_b_agency
+    - field.field.node.bears_benefit.field_b_eligibility
+    - field.field.node.bears_benefit.field_b_headline
+    - field.field.node.bears_benefit.field_b_life_events
+    - field.field.node.bears_benefit.field_b_source_is_english
+    - field.field.node.bears_benefit.field_b_source_link
+    - field.field.node.bears_benefit.field_b_summary
+    - field.field.node.bears_benefit.field_b_tags
+    - field.field.node.bears_benefit.field_b_title
+    - node.type.bears_benefit
+  module:
+    - content_moderation
+    - paragraphs
+    - path
+    - text
+id: node.bears_benefit.default
+targetEntityType: node
+bundle: bears_benefit
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_b_agency:
+    type: entity_reference_autocomplete
+    weight: 6
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_eligibility:
+    type: paragraphs
+    weight: 15
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+      features:
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings: {  }
+  field_b_headline:
+    type: text_textarea
+    weight: 2
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_life_events:
+    type: options_buttons
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_b_source_is_english:
+    type: boolean_checkbox
+    weight: 8
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_b_source_link:
+    type: string_textfield
+    weight: 7
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_summary:
+    type: text_textarea
+    weight: 3
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_tags:
+    type: options_buttons
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_b_title:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 0
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 17
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 13
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    weight: 11
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 14
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 12
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 18
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  translation:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 9
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 16
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.node.bears_criteria.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.node.bears_criteria.default.yml
@@ -1,0 +1,157 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.bears_criteria.field_b_child_dependency_option
+    - field.field.node.bears_criteria.field_b_criteria_key
+    - field.field.node.bears_criteria.field_b_has_child
+    - field.field.node.bears_criteria.field_b_id
+    - field.field.node.bears_criteria.field_b_label
+    - field.field.node.bears_criteria.field_b_name
+    - field.field.node.bears_criteria.field_b_type
+    - field.field.node.bears_criteria.field_b_values
+    - node.type.bears_criteria
+  module:
+    - content_moderation
+    - path
+id: node.bears_criteria.default
+targetEntityType: node
+bundle: bears_criteria
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_b_child_dependency_option:
+    type: string_textfield
+    weight: 14
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_criteria_key:
+    type: string_textfield
+    weight: 7
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_has_child:
+    type: boolean_checkbox
+    weight: 13
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_b_id:
+    type: string_textfield
+    weight: 8
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_label:
+    type: string_textfield
+    weight: 10
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_name:
+    type: string_textfield
+    weight: 11
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_type:
+    type: options_select
+    weight: 9
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_b_values:
+    type: string_textfield
+    weight: 12
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 0
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 16
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    weight: 3
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 6
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 4
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 17
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  translation:
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 15
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.node.bears_life_event.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.node.bears_life_event.default.yml
@@ -1,0 +1,172 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.bears_life_event.field_b_elg_criteria_desc
+    - field.field.node.bears_life_event.field_b_id
+    - field.field.node.bears_life_event.field_b_json_file
+    - field.field.node.bears_life_event.field_b_sections_elg_criteria
+    - field.field.node.bears_life_event.field_b_summary
+    - field.field.node.bears_life_event.field_b_time_estimate
+    - field.field.node.bears_life_event.field_b_title
+    - field.field.node.bears_life_event.field_b_title_prefix
+    - node.type.bears_life_event
+  module:
+    - content_moderation
+    - file
+    - paragraphs
+    - path
+    - text
+id: node.bears_life_event.default
+targetEntityType: node
+bundle: bears_life_event
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 8
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_b_elg_criteria_desc:
+    type: string_textarea
+    weight: 6
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_id:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_json_file:
+    type: file_generic
+    weight: 13
+    region: content
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+  field_b_sections_elg_criteria:
+    type: paragraphs
+    weight: 14
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+      features:
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings: {  }
+  field_b_summary:
+    type: text_textarea
+    weight: 5
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_time_estimate:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_title:
+    type: string_textfield
+    weight: 4
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_title_prefix:
+    type: string_textfield
+    weight: 3
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 0
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 16
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 11
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    weight: 9
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 12
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 10
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 17
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  translation:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 7
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 15
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.paragraph.b_benefit_eligibility.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.paragraph.b_benefit_eligibility.default.yml
@@ -1,0 +1,38 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.b_benefit_eligibility.field_b_acceptable_values
+    - field.field.paragraph.b_benefit_eligibility.field_b_criteria_key
+    - field.field.paragraph.b_benefit_eligibility.field_b_label
+    - paragraphs.paragraphs_type.b_benefit_eligibility
+id: paragraph.b_benefit_eligibility.default
+targetEntityType: paragraph
+bundle: b_benefit_eligibility
+mode: default
+content:
+  field_b_acceptable_values:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_criteria_key:
+    type: options_select
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_b_label:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.paragraph.b_levent_elg_criteria.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.paragraph.b_levent_elg_criteria.default.yml
@@ -1,0 +1,61 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.b_levent_elg_criteria.field_b_children
+    - field.field.paragraph.b_levent_elg_criteria.field_b_criteria_key
+    - field.field.paragraph.b_levent_elg_criteria.field_b_hint
+    - field.field.paragraph.b_levent_elg_criteria.field_b_legend
+    - field.field.paragraph.b_levent_elg_criteria.field_b_required
+    - paragraphs.paragraphs_type.b_levent_elg_criteria
+id: paragraph.b_levent_elg_criteria.default
+targetEntityType: paragraph
+bundle: b_levent_elg_criteria
+mode: default
+content:
+  field_b_children:
+    type: entity_reference_autocomplete
+    weight: 4
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_criteria_key:
+    type: entity_reference_autocomplete
+    weight: 0
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 0
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_hint:
+    type: string_textfield
+    weight: 3
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_legend:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_required:
+    type: boolean_checkbox
+    weight: 2
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.paragraph.b_levent_elg_section.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.paragraph.b_levent_elg_section.default.yml
@@ -1,0 +1,54 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.b_levent_elg_section.field_b_criterias
+    - field.field.paragraph.b_levent_elg_section.field_b_description
+    - field.field.paragraph.b_levent_elg_section.field_b_heading
+    - paragraphs.paragraphs_type.b_levent_elg_section
+  module:
+    - paragraphs
+    - text
+id: paragraph.b_levent_elg_section.default
+targetEntityType: paragraph
+bundle: b_levent_elg_section
+mode: default
+content:
+  field_b_criterias:
+    type: paragraphs
+    weight: 2
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+      features:
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings: {  }
+  field_b_description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_b_heading:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  field_b_fieldsets: true
+  status: true

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_agency.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_agency.default.yml
@@ -1,0 +1,45 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.bears_agency.field_b_lede
+    - field.field.node.bears_agency.field_b_summary
+    - field.field.node.bears_agency.field_b_title
+    - node.type.bears_agency
+  module:
+    - text
+    - user
+id: node.bears_agency.default
+targetEntityType: node
+bundle: bears_agency
+mode: default
+content:
+  field_b_lede:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 106
+    region: content
+  field_b_summary:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 105
+    region: content
+  field_b_title:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 102
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  langcode: true

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_agency.teaser.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_agency.teaser.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.bears_agency.field_b_lede
+    - field.field.node.bears_agency.field_b_summary
+    - field.field.node.bears_agency.field_b_title
+    - node.type.bears_agency
+  module:
+    - user
+id: node.bears_agency.teaser
+targetEntityType: node
+bundle: bears_agency
+mode: teaser
+content:
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  field_b_lede: true
+  field_b_summary: true
+  field_b_title: true
+  langcode: true

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_benefit.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_benefit.default.yml
@@ -1,0 +1,103 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.bears_benefit.field_b_agency
+    - field.field.node.bears_benefit.field_b_eligibility
+    - field.field.node.bears_benefit.field_b_headline
+    - field.field.node.bears_benefit.field_b_life_events
+    - field.field.node.bears_benefit.field_b_source_is_english
+    - field.field.node.bears_benefit.field_b_source_link
+    - field.field.node.bears_benefit.field_b_summary
+    - field.field.node.bears_benefit.field_b_tags
+    - field.field.node.bears_benefit.field_b_title
+    - node.type.bears_benefit
+  module:
+    - entity_reference_revisions
+    - text
+    - user
+id: node.bears_benefit.default
+targetEntityType: node
+bundle: bears_benefit
+mode: default
+content:
+  field_b_agency:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 114
+    region: content
+  field_b_eligibility:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 108
+    region: content
+  field_b_headline:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 113
+    region: content
+  field_b_life_events:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 105
+    region: content
+  field_b_source_is_english:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 111
+    region: content
+  field_b_source_link:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 110
+    region: content
+  field_b_summary:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 112
+    region: content
+  field_b_tags:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 104
+    region: content
+  field_b_title:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 102
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  langcode: true

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_benefit.teaser.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_benefit.teaser.yml
@@ -1,0 +1,38 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.bears_benefit.field_b_agency
+    - field.field.node.bears_benefit.field_b_eligibility
+    - field.field.node.bears_benefit.field_b_headline
+    - field.field.node.bears_benefit.field_b_life_events
+    - field.field.node.bears_benefit.field_b_source_is_english
+    - field.field.node.bears_benefit.field_b_source_link
+    - field.field.node.bears_benefit.field_b_summary
+    - field.field.node.bears_benefit.field_b_tags
+    - field.field.node.bears_benefit.field_b_title
+    - node.type.bears_benefit
+  module:
+    - user
+id: node.bears_benefit.teaser
+targetEntityType: node
+bundle: bears_benefit
+mode: teaser
+content:
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  field_b_agency: true
+  field_b_eligibility: true
+  field_b_headline: true
+  field_b_life_events: true
+  field_b_source_is_english: true
+  field_b_source_link: true
+  field_b_summary: true
+  field_b_tags: true
+  field_b_title: true
+  langcode: true

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_criteria.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_criteria.default.yml
@@ -1,0 +1,93 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.bears_criteria.field_b_child_dependency_option
+    - field.field.node.bears_criteria.field_b_criteria_key
+    - field.field.node.bears_criteria.field_b_has_child
+    - field.field.node.bears_criteria.field_b_id
+    - field.field.node.bears_criteria.field_b_label
+    - field.field.node.bears_criteria.field_b_name
+    - field.field.node.bears_criteria.field_b_type
+    - field.field.node.bears_criteria.field_b_values
+    - node.type.bears_criteria
+  module:
+    - options
+    - user
+id: node.bears_criteria.default
+targetEntityType: node
+bundle: bears_criteria
+mode: default
+content:
+  field_b_child_dependency_option:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 107
+    region: content
+  field_b_criteria_key:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 102
+    region: content
+  field_b_has_child:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 106
+    region: content
+  field_b_id:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 108
+    region: content
+  field_b_label:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 103
+    region: content
+  field_b_name:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 109
+    region: content
+  field_b_type:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 104
+    region: content
+  field_b_values:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 105
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  langcode: true

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_criteria.teaser.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_criteria.teaser.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.bears_criteria.field_b_child_dependency_option
+    - field.field.node.bears_criteria.field_b_criteria_key
+    - field.field.node.bears_criteria.field_b_has_child
+    - field.field.node.bears_criteria.field_b_id
+    - field.field.node.bears_criteria.field_b_label
+    - field.field.node.bears_criteria.field_b_name
+    - field.field.node.bears_criteria.field_b_type
+    - field.field.node.bears_criteria.field_b_values
+    - node.type.bears_criteria
+  module:
+    - user
+id: node.bears_criteria.teaser
+targetEntityType: node
+bundle: bears_criteria
+mode: teaser
+content:
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  field_b_child_dependency_option: true
+  field_b_criteria_key: true
+  field_b_has_child: true
+  field_b_id: true
+  field_b_label: true
+  field_b_name: true
+  field_b_type: true
+  field_b_values: true
+  langcode: true

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_life_event.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_life_event.default.yml
@@ -1,0 +1,93 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.bears_life_event.field_b_elg_criteria_desc
+    - field.field.node.bears_life_event.field_b_id
+    - field.field.node.bears_life_event.field_b_json_file
+    - field.field.node.bears_life_event.field_b_sections_elg_criteria
+    - field.field.node.bears_life_event.field_b_summary
+    - field.field.node.bears_life_event.field_b_time_estimate
+    - field.field.node.bears_life_event.field_b_title
+    - field.field.node.bears_life_event.field_b_title_prefix
+    - node.type.bears_life_event
+  module:
+    - entity_reference_revisions
+    - file
+    - text
+    - user
+id: node.bears_life_event.default
+targetEntityType: node
+bundle: bears_life_event
+mode: default
+content:
+  field_b_elg_criteria_desc:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  field_b_id:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 10
+    region: content
+  field_b_json_file:
+    type: file_default
+    label: above
+    settings:
+      use_description_as_link_text: true
+    third_party_settings: {  }
+    weight: 6
+    region: content
+  field_b_sections_elg_criteria:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 7
+    region: content
+  field_b_summary:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 8
+    region: content
+  field_b_time_estimate:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 12
+    region: content
+  field_b_title:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_b_title_prefix:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 11
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  langcode: true

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_life_event.teaser.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_life_event.teaser.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.bears_life_event.field_b_elg_criteria_desc
+    - field.field.node.bears_life_event.field_b_id
+    - field.field.node.bears_life_event.field_b_json_file
+    - field.field.node.bears_life_event.field_b_sections_elg_criteria
+    - field.field.node.bears_life_event.field_b_summary
+    - field.field.node.bears_life_event.field_b_time_estimate
+    - field.field.node.bears_life_event.field_b_title
+    - field.field.node.bears_life_event.field_b_title_prefix
+    - node.type.bears_life_event
+  module:
+    - user
+id: node.bears_life_event.teaser
+targetEntityType: node
+bundle: bears_life_event
+mode: teaser
+content:
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  field_b_elg_criteria_desc: true
+  field_b_id: true
+  field_b_json_file: true
+  field_b_sections_elg_criteria: true
+  field_b_summary: true
+  field_b_time_estimate: true
+  field_b_title: true
+  field_b_title_prefix: true
+  langcode: true

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.paragraph.b_benefit_eligibility.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.paragraph.b_benefit_eligibility.default.yml
@@ -1,0 +1,38 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.b_benefit_eligibility.field_b_acceptable_values
+    - field.field.paragraph.b_benefit_eligibility.field_b_criteria_key
+    - field.field.paragraph.b_benefit_eligibility.field_b_label
+    - paragraphs.paragraphs_type.b_benefit_eligibility
+id: paragraph.b_benefit_eligibility.default
+targetEntityType: paragraph
+bundle: b_benefit_eligibility
+mode: default
+content:
+  field_b_acceptable_values:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_b_criteria_key:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_b_label:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden: {  }

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.paragraph.b_levent_elg_criteria.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.paragraph.b_levent_elg_criteria.default.yml
@@ -1,0 +1,58 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.b_levent_elg_criteria.field_b_children
+    - field.field.paragraph.b_levent_elg_criteria.field_b_criteria_key
+    - field.field.paragraph.b_levent_elg_criteria.field_b_hint
+    - field.field.paragraph.b_levent_elg_criteria.field_b_legend
+    - field.field.paragraph.b_levent_elg_criteria.field_b_required
+    - paragraphs.paragraphs_type.b_levent_elg_criteria
+id: paragraph.b_levent_elg_criteria.default
+targetEntityType: paragraph
+bundle: b_levent_elg_criteria
+mode: default
+content:
+  field_b_children:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  field_b_criteria_key:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_b_hint:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_b_legend:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_b_required:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 3
+    region: content
+hidden: {  }

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.paragraph.b_levent_elg_section.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.paragraph.b_levent_elg_section.default.yml
@@ -1,0 +1,42 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.b_levent_elg_section.field_b_criterias
+    - field.field.paragraph.b_levent_elg_section.field_b_description
+    - field.field.paragraph.b_levent_elg_section.field_b_heading
+    - paragraphs.paragraphs_type.b_levent_elg_section
+  module:
+    - entity_reference_revisions
+    - text
+id: paragraph.b_levent_elg_section.default
+targetEntityType: paragraph
+bundle: b_levent_elg_section
+mode: default
+content:
+  field_b_criterias:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  field_b_description:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  field_b_heading:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  field_b_fieldsets: true

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_mode.node.teaser.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_mode.node.teaser.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.teaser
+label: Teaser
+targetEntityType: node
+cache: true

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_agency.field_b_lede.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_agency.field_b_lede.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_lede
+    - node.type.bears_agency
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats: {  }
+id: node.bears_agency.field_b_lede
+field_name: field_b_lede
+entity_type: node
+bundle: bears_agency
+label: Lede
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_agency.field_b_summary.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_agency.field_b_summary.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_summary
+    - node.type.bears_agency
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats: {  }
+id: node.bears_agency.field_b_summary
+field_name: field_b_summary
+entity_type: node
+bundle: bears_agency
+label: Summary
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_agency.field_b_title.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_agency.field_b_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_title
+    - node.type.bears_agency
+id: node.bears_agency.field_b_title
+field_name: field_b_title
+entity_type: node
+bundle: bears_agency
+label: Title
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_benefit.field_b_agency.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_benefit.field_b_agency.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_agency
+    - node.type.bears_agency
+    - node.type.bears_benefit
+id: node.bears_benefit.field_b_agency
+field_name: field_b_agency
+entity_type: node
+bundle: bears_benefit
+label: Agency
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      bears_agency: bears_agency
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_benefit.field_b_eligibility.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_benefit.field_b_eligibility.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_eligibility
+    - node.type.bears_benefit
+    - paragraphs.paragraphs_type.b_benefit_eligibility
+  module:
+    - entity_reference_revisions
+id: node.bears_benefit.field_b_eligibility
+field_name: field_b_eligibility
+entity_type: node
+bundle: bears_benefit
+label: Eligibility
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      b_benefit_eligibility: b_benefit_eligibility
+    negate: 0
+    target_bundles_drag_drop:
+      b_benefit_eligibility:
+        weight: 4
+        enabled: true
+      b_levent_eligibility_criteria:
+        weight: 5
+        enabled: false
+      b_levent_top_level_filter:
+        weight: 6
+        enabled: false
+field_type: entity_reference_revisions

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_benefit.field_b_headline.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_benefit.field_b_headline.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_headline
+    - node.type.bears_benefit
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats: {  }
+id: node.bears_benefit.field_b_headline
+field_name: field_b_headline
+entity_type: node
+bundle: bears_benefit
+label: Headline
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_benefit.field_b_life_events.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_benefit.field_b_life_events.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_life_events
+    - node.type.bears_benefit
+    - node.type.bears_life_event
+id: node.bears_benefit.field_b_life_events
+field_name: field_b_life_events
+entity_type: node
+bundle: bears_benefit
+label: 'Life Events'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      bears_life_event: bears_life_event
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_benefit.field_b_source_is_english.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_benefit.field_b_source_is_english.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_source_is_english
+    - node.type.bears_benefit
+id: node.bears_benefit.field_b_source_is_english
+field_name: field_b_source_is_english
+entity_type: node
+bundle: bears_benefit
+label: 'Source Is English'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_benefit.field_b_source_link.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_benefit.field_b_source_link.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_source_link
+    - node.type.bears_benefit
+id: node.bears_benefit.field_b_source_link
+field_name: field_b_source_link
+entity_type: node
+bundle: bears_benefit
+label: 'Source Link'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_benefit.field_b_summary.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_benefit.field_b_summary.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_summary
+    - node.type.bears_benefit
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats: {  }
+id: node.bears_benefit.field_b_summary
+field_name: field_b_summary
+entity_type: node
+bundle: bears_benefit
+label: Summary
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_benefit.field_b_tags.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_benefit.field_b_tags.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_tags
+    - node.type.bears_benefit
+    - taxonomy.vocabulary.bears_tags
+id: node.bears_benefit.field_b_tags
+field_name: field_b_tags
+entity_type: node
+bundle: bears_benefit
+label: Tags
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      bears_tags: bears_tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_benefit.field_b_title.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_benefit.field_b_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_title
+    - node.type.bears_benefit
+id: node.bears_benefit.field_b_title
+field_name: field_b_title
+entity_type: node
+bundle: bears_benefit
+label: Title
+description: "Benefit title is used to identify the benefit and the benefit card on the life event page. Wrap title in quotes. Maximum character limit is 82.\r\n"
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_criteria.field_b_child_dependency_option.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_criteria.field_b_child_dependency_option.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_child_dependency_option
+    - node.type.bears_criteria
+id: node.bears_criteria.field_b_child_dependency_option
+field_name: field_b_child_dependency_option
+entity_type: node
+bundle: bears_criteria
+label: 'Child Dependency Option'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_criteria.field_b_criteria_key.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_criteria.field_b_criteria_key.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_criteria_key
+    - node.type.bears_criteria
+id: node.bears_criteria.field_b_criteria_key
+field_name: field_b_criteria_key
+entity_type: node
+bundle: bears_criteria
+label: 'Criteria Key'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_criteria.field_b_has_child.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_criteria.field_b_has_child.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_has_child
+    - node.type.bears_criteria
+id: node.bears_criteria.field_b_has_child
+field_name: field_b_has_child
+entity_type: node
+bundle: bears_criteria
+label: 'Has Child'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_criteria.field_b_id.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_criteria.field_b_id.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_id
+    - node.type.bears_criteria
+id: node.bears_criteria.field_b_id
+field_name: field_b_id
+entity_type: node
+bundle: bears_criteria
+label: ID
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_criteria.field_b_label.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_criteria.field_b_label.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_label
+    - node.type.bears_criteria
+id: node.bears_criteria.field_b_label
+field_name: field_b_label
+entity_type: node
+bundle: bears_criteria
+label: Label
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_criteria.field_b_name.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_criteria.field_b_name.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_name
+    - node.type.bears_criteria
+id: node.bears_criteria.field_b_name
+field_name: field_b_name
+entity_type: node
+bundle: bears_criteria
+label: Name
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_criteria.field_b_type.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_criteria.field_b_type.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_type
+    - node.type.bears_criteria
+  module:
+    - options
+id: node.bears_criteria.field_b_type
+field_name: field_b_type
+entity_type: node
+bundle: bears_criteria
+label: Type
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_criteria.field_b_values.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_criteria.field_b_values.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_values
+    - node.type.bears_criteria
+id: node.bears_criteria.field_b_values
+field_name: field_b_values
+entity_type: node
+bundle: bears_criteria
+label: Values
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_life_event.field_b_elg_criteria_desc.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_life_event.field_b_elg_criteria_desc.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_elg_criteria_desc
+    - node.type.bears_life_event
+id: node.bears_life_event.field_b_elg_criteria_desc
+field_name: field_b_elg_criteria_desc
+entity_type: node
+bundle: bears_life_event
+label: 'Eligibility Criteria Description'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_life_event.field_b_id.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_life_event.field_b_id.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_id
+    - node.type.bears_life_event
+id: node.bears_life_event.field_b_id
+field_name: field_b_id
+entity_type: node
+bundle: bears_life_event
+label: ID
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_life_event.field_b_json_file.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_life_event.field_b_json_file.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_json_file
+    - node.type.bears_life_event
+  module:
+    - file
+id: node.bears_life_event.field_b_json_file
+field_name: field_b_json_file
+entity_type: node
+bundle: bears_life_event
+label: 'JSON File'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: bears/api
+  file_extensions: 'txt json'
+  max_filesize: ''
+  description_field: false
+field_type: file

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_life_event.field_b_sections_elg_criteria.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_life_event.field_b_sections_elg_criteria.yml
@@ -1,0 +1,42 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_sections_elg_criteria
+    - node.type.bears_life_event
+    - paragraphs.paragraphs_type.b_levent_elg_section
+  module:
+    - entity_reference_revisions
+id: node.bears_life_event.field_b_sections_elg_criteria
+field_name: field_b_sections_elg_criteria
+entity_type: node
+bundle: bears_life_event
+label: 'Sections Eligibility Criteria'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      b_levent_elg_section: b_levent_elg_section
+    negate: 0
+    target_bundles_drag_drop:
+      b_benefit_eligibility:
+        weight: 6
+        enabled: false
+      b_levent_elg_fieldset:
+        weight: 7
+        enabled: false
+      b_levent_elg_section:
+        weight: 8
+        enabled: true
+      b_levent_eligibility_criteria:
+        weight: 9
+        enabled: false
+      b_levent_top_level_filter:
+        weight: 10
+        enabled: false
+field_type: entity_reference_revisions

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_life_event.field_b_summary.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_life_event.field_b_summary.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_summary
+    - node.type.bears_life_event
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats: {  }
+id: node.bears_life_event.field_b_summary
+field_name: field_b_summary
+entity_type: node
+bundle: bears_life_event
+label: Summary
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_life_event.field_b_time_estimate.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_life_event.field_b_time_estimate.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_time_estimate
+    - node.type.bears_life_event
+id: node.bears_life_event.field_b_time_estimate
+field_name: field_b_time_estimate
+entity_type: node
+bundle: bears_life_event
+label: 'Time Estimate'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_life_event.field_b_title.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_life_event.field_b_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_title
+    - node.type.bears_life_event
+id: node.bears_life_event.field_b_title
+field_name: field_b_title
+entity_type: node
+bundle: bears_life_event
+label: Title
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_life_event.field_b_title_prefix.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_life_event.field_b_title_prefix.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_b_title_prefix
+    - node.type.bears_life_event
+id: node.bears_life_event.field_b_title_prefix
+field_name: field_b_title_prefix
+entity_type: node
+bundle: bears_life_event
+label: 'Title Prefix'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.paragraph.b_benefit_eligibility.field_b_acceptable_values.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.paragraph.b_benefit_eligibility.field_b_acceptable_values.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_b_acceptable_values
+    - paragraphs.paragraphs_type.b_benefit_eligibility
+id: paragraph.b_benefit_eligibility.field_b_acceptable_values
+field_name: field_b_acceptable_values
+entity_type: paragraph
+bundle: b_benefit_eligibility
+label: 'Acceptable Values'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.paragraph.b_benefit_eligibility.field_b_criteria_key.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.paragraph.b_benefit_eligibility.field_b_criteria_key.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_b_criteria_key
+    - node.type.bears_criteria
+    - paragraphs.paragraphs_type.b_benefit_eligibility
+id: paragraph.b_benefit_eligibility.field_b_criteria_key
+field_name: field_b_criteria_key
+entity_type: paragraph
+bundle: b_benefit_eligibility
+label: 'Criteria Key'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      bears_criteria: bears_criteria
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.paragraph.b_benefit_eligibility.field_b_label.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.paragraph.b_benefit_eligibility.field_b_label.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_b_label
+    - paragraphs.paragraphs_type.b_benefit_eligibility
+id: paragraph.b_benefit_eligibility.field_b_label
+field_name: field_b_label
+entity_type: paragraph
+bundle: b_benefit_eligibility
+label: Label
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.paragraph.b_levent_elg_criteria.field_b_children.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.paragraph.b_levent_elg_criteria.field_b_children.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_b_children
+    - node.type.bears_criteria
+    - paragraphs.paragraphs_type.b_levent_elg_criteria
+id: paragraph.b_levent_elg_criteria.field_b_children
+field_name: field_b_children
+entity_type: paragraph
+bundle: b_levent_elg_criteria
+label: Children
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      bears_criteria: bears_criteria
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.paragraph.b_levent_elg_criteria.field_b_criteria_key.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.paragraph.b_levent_elg_criteria.field_b_criteria_key.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_b_criteria_key
+    - node.type.bears_criteria
+    - paragraphs.paragraphs_type.b_levent_elg_criteria
+id: paragraph.b_levent_elg_criteria.field_b_criteria_key
+field_name: field_b_criteria_key
+entity_type: paragraph
+bundle: b_levent_elg_criteria
+label: 'Criteria Key'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      bears_criteria: bears_criteria
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.paragraph.b_levent_elg_criteria.field_b_hint.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.paragraph.b_levent_elg_criteria.field_b_hint.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_b_hint
+    - paragraphs.paragraphs_type.b_levent_elg_criteria
+id: paragraph.b_levent_elg_criteria.field_b_hint
+field_name: field_b_hint
+entity_type: paragraph
+bundle: b_levent_elg_criteria
+label: Hint
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.paragraph.b_levent_elg_criteria.field_b_legend.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.paragraph.b_levent_elg_criteria.field_b_legend.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_b_legend
+    - paragraphs.paragraphs_type.b_levent_elg_criteria
+id: paragraph.b_levent_elg_criteria.field_b_legend
+field_name: field_b_legend
+entity_type: paragraph
+bundle: b_levent_elg_criteria
+label: Legend
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.paragraph.b_levent_elg_criteria.field_b_required.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.paragraph.b_levent_elg_criteria.field_b_required.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_b_required
+    - paragraphs.paragraphs_type.b_levent_elg_criteria
+id: paragraph.b_levent_elg_criteria.field_b_required
+field_name: field_b_required
+entity_type: paragraph
+bundle: b_levent_elg_criteria
+label: Required
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.paragraph.b_levent_elg_section.field_b_criterias.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.paragraph.b_levent_elg_section.field_b_criterias.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_b_criterias
+    - paragraphs.paragraphs_type.b_levent_elg_criteria
+    - paragraphs.paragraphs_type.b_levent_elg_section
+  module:
+    - entity_reference_revisions
+id: paragraph.b_levent_elg_section.field_b_criterias
+field_name: field_b_criterias
+entity_type: paragraph
+bundle: b_levent_elg_section
+label: Criterias
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      b_levent_elg_criteria: b_levent_elg_criteria
+    negate: 0
+    target_bundles_drag_drop:
+      b_benefit_eligibility:
+        weight: 5
+        enabled: false
+      b_levent_elg_criteria:
+        weight: 5
+        enabled: true
+      b_levent_elg_section:
+        weight: 6
+        enabled: false
+field_type: entity_reference_revisions

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.paragraph.b_levent_elg_section.field_b_description.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.paragraph.b_levent_elg_section.field_b_description.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_b_description
+    - paragraphs.paragraphs_type.b_levent_elg_section
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats: {  }
+id: paragraph.b_levent_elg_section.field_b_description
+field_name: field_b_description
+entity_type: paragraph
+bundle: b_levent_elg_section
+label: Description
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.paragraph.b_levent_elg_section.field_b_heading.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.paragraph.b_levent_elg_section.field_b_heading.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_b_heading
+    - paragraphs.paragraphs_type.b_levent_elg_section
+id: paragraph.b_levent_elg_section.field_b_heading
+field_name: field_b_heading
+entity_type: paragraph
+bundle: b_levent_elg_section
+label: Heading
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_agency.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_agency.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_b_agency
+field_name: field_b_agency
+entity_type: node
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_child_dependency_option.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_child_dependency_option.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_b_child_dependency_option
+field_name: field_b_child_dependency_option
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_criteria_key.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_criteria_key.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_b_criteria_key
+field_name: field_b_criteria_key
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_elg_criteria_desc.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_elg_criteria_desc.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_b_elg_criteria_desc
+field_name: field_b_elg_criteria_desc
+entity_type: node
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_eligibility.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_eligibility.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+id: node.field_b_eligibility
+field_name: field_b_eligibility
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_has_child.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_has_child.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_b_has_child
+field_name: field_b_has_child
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_headline.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_headline.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+    - text
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_b_headline
+field_name: field_b_headline
+entity_type: node
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_id.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_id.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_b_id
+field_name: field_b_id
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_json_file.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_json_file.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - node
+id: node.field_b_json_file
+field_name: field_b_json_file
+entity_type: node
+type: file
+settings:
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+module: file
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_label.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_label.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_b_label
+field_name: field_b_label
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_lede.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_lede.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+    - text
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_b_lede
+field_name: field_b_lede
+entity_type: node
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_life_events.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_life_events.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_b_life_events
+field_name: field_b_life_events
+entity_type: node
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_name.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_name.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_b_name
+field_name: field_b_name
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_sections_elg_criteria.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_sections_elg_criteria.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+id: node.field_b_sections_elg_criteria
+field_name: field_b_sections_elg_criteria
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_source_is_english.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_source_is_english.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_b_source_is_english
+field_name: field_b_source_is_english
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_source_link.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_source_link.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_b_source_link
+field_name: field_b_source_link
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_summary.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_summary.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+    - text
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_b_summary
+field_name: field_b_summary
+entity_type: node
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_tags.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_tags.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_b_tags
+field_name: field_b_tags
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_time_estimate.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_time_estimate.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_b_time_estimate
+field_name: field_b_time_estimate
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_title.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_title.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_b_title
+field_name: field_b_title
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_title_prefix.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_title_prefix.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_b_title_prefix
+field_name: field_b_title_prefix
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_type.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_type.yml
@@ -1,0 +1,32 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_b_type
+field_name: field_b_type
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: Boolean
+      label: Boolean
+    -
+      value: Date
+      label: Date
+    -
+      value: Select
+      label: Select
+    -
+      value: Radio
+      label: Radio
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_values.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_b_values.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_b_values
+field_name: field_b_values
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.paragraph.field_b_acceptable_values.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.paragraph.field_b_acceptable_values.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_b_acceptable_values
+field_name: field_b_acceptable_values
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.paragraph.field_b_children.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.paragraph.field_b_children.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+    - paragraphs
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: paragraph.field_b_children
+field_name: field_b_children
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.paragraph.field_b_criteria_key.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.paragraph.field_b_criteria_key.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+    - paragraphs
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: paragraph.field_b_criteria_key
+field_name: field_b_criteria_key
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.paragraph.field_b_criterias.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.paragraph.field_b_criterias.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - field_permissions
+    - paragraphs
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: paragraph.field_b_criterias
+field_name: field_b_criterias
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.paragraph.field_b_description.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.paragraph.field_b_description.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - paragraphs
+    - text
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: paragraph.field_b_description
+field_name: field_b_description
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.paragraph.field_b_heading.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.paragraph.field_b_heading.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_b_heading
+field_name: field_b_heading
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.paragraph.field_b_hint.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.paragraph.field_b_hint.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - paragraphs
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: paragraph.field_b_hint
+field_name: field_b_hint
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.paragraph.field_b_label.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.paragraph.field_b_label.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_b_label
+field_name: field_b_label
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.paragraph.field_b_legend.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.paragraph.field_b_legend.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - paragraphs
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: paragraph.field_b_legend
+field_name: field_b_legend
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.paragraph.field_b_required.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.paragraph.field_b_required.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_b_required
+field_name: field_b_required
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/usagov_bears/modules/usagov_bears_content/config/optional/node.type.bears_agency.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/node.type.bears_agency.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+    - node_menus
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+  node_menus:
+    enabled: 0
+    languages:
+      en:
+        available_menus:
+          - main
+        parent: 'main:'
+      es:
+        available_menus:
+          - main
+        parent: 'main:'
+name: 'Bears Agency'
+type: bears_agency
+description: 'Bears Agency'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: true

--- a/usagov_bears/modules/usagov_bears_content/config/optional/node.type.bears_benefit.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/node.type.bears_benefit.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+    - node_menus
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+  node_menus:
+    enabled: 0
+    languages:
+      en:
+        available_menus:
+          - main
+        parent: 'main:'
+      es:
+        available_menus:
+          - main
+        parent: 'main:'
+name: 'Bears Benefit'
+type: bears_benefit
+description: 'Bears Benefit'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: true

--- a/usagov_bears/modules/usagov_bears_content/config/optional/node.type.bears_criteria.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/node.type.bears_criteria.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+name: 'Bears Criteria'
+type: bears_criteria
+description: 'Bears Criteria'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: true

--- a/usagov_bears/modules/usagov_bears_content/config/optional/node.type.bears_life_event.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/node.type.bears_life_event.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+name: 'Bears Life Event'
+type: bears_life_event
+description: 'Bears Life Event'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: true

--- a/usagov_bears/modules/usagov_bears_content/config/optional/paragraphs.paragraphs_type.b_benefit_eligibility.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/paragraphs.paragraphs_type.b_benefit_eligibility.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: b_benefit_eligibility
+label: 'Bears Benefit Eligibility'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/usagov_bears/modules/usagov_bears_content/config/optional/paragraphs.paragraphs_type.b_levent_elg_criteria.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/paragraphs.paragraphs_type.b_levent_elg_criteria.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: b_levent_elg_criteria
+label: 'Bears Life Event Eligibility Criteria'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/usagov_bears/modules/usagov_bears_content/config/optional/paragraphs.paragraphs_type.b_levent_elg_section.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/paragraphs.paragraphs_type.b_levent_elg_section.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: b_levent_elg_section
+label: 'Bears Life Event Eligibility Section'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/usagov_bears/modules/usagov_bears_content/config/optional/taxonomy.vocabulary.bears_tags.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/taxonomy.vocabulary.bears_tags.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'Bears Tags'
+vid: bears_tags
+description: 'Bears Tags'
+weight: 0


### PR DESCRIPTION
## PR Summary

Content entity configuration of BEARS content type, paragraph, and taxonomy.

## Related Github Issue

- fixes #122 

## Detailed Testing steps

Follow usagov_bears module README.md to enable BEARS modules:
```
bin/drush pm:enable usagov_bears_block
bin/drush pm:enable usagov_bears_content
bin/drush pm:enable usagov_bears_api
bin/drush pm:enable usagov_bears
```

Import content entity configuration in usagov_bears_content module
```
bin/drush config:import \
  --partial \
  --source=modules/custom/usagov_bears/modules/usagov_bears_content/config/optional
```

Check the following Bears content entities created.

Taxonomy
http://localhost/admin/structure/taxonomy

- Bears Tags

Paragraph
http://localhost/admin/structure/paragraphs_type

- Bears Life Event Eligibility Criteria
- Bears Life Event Eligibility Section

Content type
http://localhost/admin/structure/types

- Bears Agency
- Bears Criteria
- Bears Life Event
