### PR TITLE
includes static and dynamic data attribute for analytics

### DIFF
--- a/bears-app/src/shared/components/Accordion/index.jsx
+++ b/bears-app/src/shared/components/Accordion/index.jsx
@@ -14,7 +14,14 @@ import './_index.scss'
  * @param {bool} isExpanded - sets the open state of an accordion
  * @return {html} returns a semantic html button element
  */
-const Accordion = ({ id, heading, subHeading, children, isExpanded }) => {
+const Accordion = ({
+  id,
+  heading,
+  subHeading,
+  children,
+  isExpanded,
+  ...props
+}) => {
   /**
    * a hook that hanldes our open state of the accordion
    * @function
@@ -40,7 +47,7 @@ const Accordion = ({ id, heading, subHeading, children, isExpanded }) => {
     )
 
   return (
-    <div className="benefit-accordion">
+    <div className="benefit-accordion" {...props}>
       {/* we don't use `usa-accordion` class because it is too opinionated about control, this throws an error from the uswds javascript, but does not impact/break functionality */}
       <h4 className="usa-accordion__heading">
         <button

--- a/bears-app/src/shared/components/BenefitAccordionGroup/index.jsx
+++ b/bears-app/src/shared/components/BenefitAccordionGroup/index.jsx
@@ -116,6 +116,8 @@ const BenefitAccordionGroup = ({ data, entryKey, expandAll }) => {
               subHeading={eligibleStatus}
               aria-expanded={isExpandAll}
               isExpanded={isExpandAll}
+              data-analytics="benefit-accordion"
+              data-analytics-content={title}
             >
               <Heading className="benefit-detail-title" headingLevel={4}>
                 {`Provided by ${agency.title}`}


### PR DESCRIPTION
## PR Summary

This is set up as a test to include `data-analytics` (static) and `data-analytics-content` (dynamic) for GTM to test event relations in the Benefit Accordion Group component.

## Detailed Testing steps

Link to testing steps in the issue or list them here:

- [ ] navigate to https://bears-storybook.app.cloud.gov/iframe.html?args=&id=shared-components-benefitaccordiongroup--primary&viewMode=story
- [ ] in the main wrapper of the component the two data attributes should appear
