### PR TITLE
Task/add partial config import to pipeline2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ workflows:
           filters:
             branches:
               only: 
-                - task/add-partial-config-import-to-pipeline2
+                - main
 
   create-component-library-workflow:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,8 +82,14 @@ jobs:
           name: Enable bears module
           command: |
             cf login -a https://api.fr.cloud.gov -u "$CF_USER" -p "$CF_PASSWORD" -o "$CF_ORG"  -s "$CF_SPACE"
-            cf apps
-            cf ssh cms --command "/var/www/vendor/bin/drush --version && /var/www/vendor/bin/drush pm:enable usagov_bears_block && /var/www/vendor/bin/drush pm:enable usagov_bears_content && /var/www/vendor/bin/drush pm:enable usagov_bears_api && /var/www/vendor/bin/drush pm:enable usagov_bears && /var/www/vendor/bin/drush cr"
+            cf ssh cms --command "/var/www/vendor/bin/drush state:set system.maintenance_mode 0 && \
+                                  /var/www/vendor/bin/drush pm:uninstall usagov_login && \
+                                  /var/www/vendor/bin/drush pm:enable usagov_bears_block && \
+                                  /var/www/vendor/bin/drush pm:enable usagov_bears_content && \
+                                  /var/www/vendor/bin/drush pm:enable usagov_bears_api && \
+                                  /var/www/vendor/bin/drush pm:enable usagov_bears && \
+                                  /var/www/vendor/bin/drush -y config:import --partial --source=modules/custom/usagov_bears/modules/usagov_bears_content/config/optional && \
+                                  /var/www/vendor/bin/drush cr"
   
   component-library:
     machine:
@@ -169,7 +175,7 @@ workflows:
           filters:
             branches:
               only: 
-                - main
+                - task/add-partial-config-import-to-pipeline2
 
   create-component-library-workflow:
     jobs:


### PR DESCRIPTION
## PR Summary

This PR introduces following changes to the cms_build_and_deploy_workflow in the pipeline:

- It does a partial config import the following `modules/custom/usagov_bears/modules/usagov_bears_content/config/optional`
- It disables `usagov_login` 
- It sets the system.maintenance_mode off

## Related Github Issue

- fixes #[Add partial config import to pipeline#185](https://github.com/GSA/px-bears-drupal/issues/185)
