### PR TITLE
Task/freeze USAGOV submodule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,9 +138,7 @@ jobs:
             cd px-bears-drupal
             git submodule init
             git submodule update
-            cd usagov-2021
-            git checkout dev
-            git checkout 3ff7fb93a47daef6d4e33d3ec9beef72b8e386cd
+
 
       - run:
           name: Injecting container name to the manifest.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,8 @@ jobs:
             cd px-bears-drupal
             git submodule init
             git submodule update
+            git checkout dev
+            git checkout 3ff7fb93a47daef6d4e33d3ec9beef72b8e386cd
 
       - run:
           name: Injecting container name to the manifest.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,10 @@ jobs:
             cd px-bears-drupal
             git submodule init
             git submodule update
+            cd usagov-2021
+            git checkout dev
+            git checkout 3ff7fb93a47daef6d4e33d3ec9beef72b8e386cd
+
 
       - run:
           name: Moving the bears app into usagov-2021 module
@@ -169,7 +173,7 @@ workflows:
           filters:
             branches:
               only: 
-                - main
+                - task/freeze-USAGOV-Submodule
 
   create-component-library-workflow:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,7 @@ jobs:
             cd px-bears-drupal
             git submodule init
             git submodule update
+            cd usagov-2021
             git checkout dev
             git checkout 3ff7fb93a47daef6d4e33d3ec9beef72b8e386cd
 


### PR DESCRIPTION
## PR Summary

This PR makes sure that the pipeline checks out the USAGOV Submodule to a specific commit SHA to make sure that the database stays synced with the code and doesn't break the application.

The commit branch and SHA can be updated to a later version in the future if needed.

## Related Github Issue

- fixes #[Freeze USAGOV Submodule to a specific hash#264](https://github.com/GSA/px-bears-drupal/issues/264)

