### PR TITLE
[318] - Remove config import from the pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,6 @@ jobs:
                                   /var/www/vendor/bin/drush pm:enable usagov_bears_content && \
                                   /var/www/vendor/bin/drush pm:enable usagov_bears_api && \
                                   /var/www/vendor/bin/drush pm:enable usagov_bears && \
-                                  /var/www/vendor/bin/drush -y config:import --partial --source=modules/custom/usagov_bears/modules/usagov_bears_content/config/optional && \
                                   /var/www/vendor/bin/drush cr"
   
   component-library:


### PR DESCRIPTION
## PR Summary

This PR removes `/var/www/vendor/bin/drush -y config:import --partial --source=modules/custom/usagov_bears/modules/usagov_bears_content/config/optional` command from the pipeline as per the senior developer's request.

## Related Github Issue

- fixes #[Remove config import from pipeline#318](https://github.com/GSA/px-bears-drupal/issues/318)

