### PR TITLE
add language toggle

### DIFF
--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.node.bears_agency.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.node.bears_agency.default.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - field.field.node.bears_agency.field_b_lede
     - field.field.node.bears_agency.field_b_summary
+    - field.field.node.bears_agency.field_language_toggle
     - node.type.bears_agency
   module:
     - content_moderation
@@ -16,13 +17,13 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 2
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
   field_b_lede:
     type: text_textarea
-    weight: 11
+    weight: 12
     region: content
     settings:
       rows: 5
@@ -30,10 +31,20 @@ content:
     third_party_settings: {  }
   field_b_summary:
     type: text_textarea
-    weight: 10
+    weight: 11
     region: content
     settings:
       rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_language_toggle:
+    type: entity_reference_autocomplete
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
       placeholder: ''
     third_party_settings: {  }
   langcode:
@@ -45,40 +56,40 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 5
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
-    type: boolean_checkbox
-    weight: 3
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
-  status:
-    type: boolean_checkbox
-    weight: 6
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
-  sticky:
     type: boolean_checkbox
     weight: 4
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 7
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 5
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 9
+    weight: 10
     region: content
     settings:
       size: 60
@@ -91,7 +102,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 1
+    weight: 2
     region: content
     settings:
       match_operator: CONTAINS
@@ -100,7 +111,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.node.bears_benefit.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.node.bears_benefit.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.bears_benefit.field_b_source_link
     - field.field.node.bears_benefit.field_b_summary
     - field.field.node.bears_benefit.field_b_tags
+    - field.field.node.bears_benefit.field_language_toggle
     - node.type.bears_benefit
   module:
     - content_moderation
@@ -24,13 +25,13 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
   field_b_agency:
     type: entity_reference_autocomplete
-    weight: 6
+    weight: 7
     region: content
     settings:
       match_operator: CONTAINS
@@ -40,7 +41,7 @@ content:
     third_party_settings: {  }
   field_b_eligibility:
     type: paragraphs
-    weight: 16
+    weight: 17
     region: content
     settings:
       title: Paragraph
@@ -58,7 +59,7 @@ content:
     third_party_settings: {  }
   field_b_headline:
     type: text_textarea
-    weight: 2
+    weight: 3
     region: content
     settings:
       rows: 5
@@ -66,27 +67,27 @@ content:
     third_party_settings: {  }
   field_b_initial_elg_length:
     type: number
-    weight: 15
+    weight: 16
     region: content
     settings:
       placeholder: ''
     third_party_settings: {  }
   field_b_life_events:
     type: options_buttons
-    weight: 5
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
   field_b_source_is_english:
     type: boolean_checkbox
-    weight: 8
+    weight: 9
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_b_source_link:
     type: string_textfield
-    weight: 7
+    weight: 8
     region: content
     settings:
       size: 60
@@ -94,7 +95,7 @@ content:
     third_party_settings: {  }
   field_b_summary:
     type: text_textarea
-    weight: 3
+    weight: 4
     region: content
     settings:
       rows: 5
@@ -102,9 +103,19 @@ content:
     third_party_settings: {  }
   field_b_tags:
     type: options_buttons
-    weight: 4
+    weight: 5
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_language_toggle:
+    type: entity_reference_autocomplete
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   langcode:
     type: language_select
@@ -115,40 +126,40 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 18
+    weight: 19
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 13
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
-    type: boolean_checkbox
-    weight: 11
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
-  status:
-    type: boolean_checkbox
-    weight: 14
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
-  sticky:
     type: boolean_checkbox
     weight: 12
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 15
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 13
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 1
+    weight: 2
     region: content
     settings:
       size: 60
@@ -161,7 +172,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 9
+    weight: 10
     region: content
     settings:
       match_operator: CONTAINS
@@ -170,7 +181,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 17
+    weight: 18
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.node.bears_criteria.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.node.bears_criteria.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.bears_criteria.field_b_name
     - field.field.node.bears_criteria.field_b_type
     - field.field.node.bears_criteria.field_b_values
+    - field.field.node.bears_criteria.field_language_toggle
     - node.type.bears_criteria
   module:
     - content_moderation
@@ -21,13 +22,13 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 2
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
   field_b_child_dependency_option:
     type: string_textfield
-    weight: 15
+    weight: 16
     region: content
     settings:
       size: 60
@@ -35,7 +36,7 @@ content:
     third_party_settings: {  }
   field_b_criteria_key:
     type: string_textfield
-    weight: 8
+    weight: 9
     region: content
     settings:
       size: 60
@@ -43,14 +44,14 @@ content:
     third_party_settings: {  }
   field_b_has_child:
     type: boolean_checkbox
-    weight: 14
+    weight: 15
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_b_id:
     type: string_textfield
-    weight: 9
+    weight: 10
     region: content
     settings:
       size: 60
@@ -58,7 +59,7 @@ content:
     third_party_settings: {  }
   field_b_label:
     type: string_textfield
-    weight: 11
+    weight: 12
     region: content
     settings:
       size: 60
@@ -66,7 +67,7 @@ content:
     third_party_settings: {  }
   field_b_name:
     type: string_textfield
-    weight: 12
+    weight: 13
     region: content
     settings:
       size: 60
@@ -74,15 +75,25 @@ content:
     third_party_settings: {  }
   field_b_type:
     type: options_select
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
   field_b_values:
     type: string_textfield
-    weight: 13
+    weight: 14
     region: content
     settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_language_toggle:
+    type: entity_reference_autocomplete
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
     third_party_settings: {  }
@@ -95,40 +106,40 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 17
+    weight: 18
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 5
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
-    type: boolean_checkbox
-    weight: 3
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
-  status:
-    type: boolean_checkbox
-    weight: 6
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
-  sticky:
     type: boolean_checkbox
     weight: 4
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 7
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 5
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 7
+    weight: 8
     region: content
     settings:
       size: 60
@@ -141,7 +152,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 1
+    weight: 2
     region: content
     settings:
       match_operator: CONTAINS
@@ -150,7 +161,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 16
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.node.bears_life_event.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.node.bears_life_event.default.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - field.field.node.bears_life_event.field_b_id
     - field.field.node.bears_life_event.field_json_data_file
+    - field.field.node.bears_life_event.field_language_toggle
     - field.field.node.bears_life_event.field_summary
     - node.type.bears_life_event
   module:
@@ -17,13 +18,13 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 5
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
   field_b_id:
     type: string_textfield
-    weight: 2
+    weight: 3
     region: content
     settings:
       size: 60
@@ -31,14 +32,24 @@ content:
     third_party_settings: {  }
   field_json_data_file:
     type: file_generic
-    weight: 12
+    weight: 13
     region: content
     settings:
       progress_indicator: throbber
     third_party_settings: {  }
+  field_language_toggle:
+    type: entity_reference_autocomplete
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_summary:
     type: string_textarea
-    weight: 3
+    weight: 4
     region: content
     settings:
       rows: 5
@@ -53,40 +64,40 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
-    type: boolean_checkbox
-    weight: 6
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
-  status:
-    type: boolean_checkbox
-    weight: 11
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
-  sticky:
     type: boolean_checkbox
     weight: 7
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 12
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 8
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 1
+    weight: 2
     region: content
     settings:
       size: 60
@@ -94,7 +105,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 4
+    weight: 5
     region: content
     settings:
       match_operator: CONTAINS
@@ -103,7 +114,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 9
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.node.bears_life_event_form.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.node.bears_life_event_form.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.bears_life_event_form.field_b_summary
     - field.field.node.bears_life_event_form.field_b_time_estimate
     - field.field.node.bears_life_event_form.field_b_title_prefix
+    - field.field.node.bears_life_event_form.field_language_toggle
     - node.type.bears_life_event_form
   module:
     - content_moderation
@@ -21,13 +22,13 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   field_b_elg_criteria_desc:
     type: string_textarea
-    weight: 6
+    weight: 7
     region: content
     settings:
       rows: 5
@@ -35,7 +36,7 @@ content:
     third_party_settings: {  }
   field_b_id:
     type: string_textfield
-    weight: 1
+    weight: 2
     region: content
     settings:
       size: 60
@@ -43,7 +44,7 @@ content:
     third_party_settings: {  }
   field_b_sections_elg_criteria:
     type: mmf_entity_reference_revisions
-    weight: 12
+    weight: 13
     region: content
     settings:
       min_count: 1
@@ -56,7 +57,7 @@ content:
     third_party_settings: {  }
   field_b_summary:
     type: text_textarea
-    weight: 5
+    weight: 6
     region: content
     settings:
       rows: 5
@@ -64,7 +65,7 @@ content:
     third_party_settings: {  }
   field_b_time_estimate:
     type: string_textfield
-    weight: 2
+    weight: 3
     region: content
     settings:
       size: 60
@@ -72,9 +73,19 @@ content:
     third_party_settings: {  }
   field_b_title_prefix:
     type: string_textfield
-    weight: 3
+    weight: 4
     region: content
     settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_language_toggle:
+    type: entity_reference_autocomplete
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
     third_party_settings: {  }
@@ -93,13 +104,13 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 11
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 9
+    weight: 10
     region: content
     settings:
       display_label: true
@@ -113,14 +124,14 @@ content:
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 10
+    weight: 11
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 4
+    weight: 5
     region: content
     settings:
       size: 60
@@ -128,7 +139,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 7
+    weight: 8
     region: content
     settings:
       match_operator: CONTAINS

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_agency.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_agency.default.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - field.field.node.bears_agency.field_b_lede
     - field.field.node.bears_agency.field_b_summary
+    - field.field.node.bears_agency.field_language_toggle
     - node.type.bears_agency
   module:
     - text
@@ -18,19 +19,35 @@ content:
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 106
+    weight: 2
     region: content
   field_b_summary:
     type: text_default
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 105
+    weight: 1
+    region: content
+  field_language_toggle:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  langcode:
+    type: language
+    label: above
+    settings:
+      link_to_entity: false
+      native_language: false
+    third_party_settings: {  }
+    weight: 3
     region: content
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 100
+    weight: 0
     region: content
-hidden:
-  langcode: true
+hidden: {  }

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_agency.teaser.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_agency.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.bears_agency.field_b_lede
     - field.field.node.bears_agency.field_b_summary
+    - field.field.node.bears_agency.field_language_toggle
     - node.type.bears_agency
   module:
     - user
@@ -21,4 +22,5 @@ content:
 hidden:
   field_b_lede: true
   field_b_summary: true
+  field_language_toggle: true
   langcode: true

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_benefit.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_benefit.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.bears_benefit.field_b_source_link
     - field.field.node.bears_benefit.field_b_summary
     - field.field.node.bears_benefit.field_b_tags
+    - field.field.node.bears_benefit.field_language_toggle
     - node.type.bears_benefit
   module:
     - entity_reference_revisions
@@ -95,10 +96,26 @@ content:
     third_party_settings: {  }
     weight: 3
     region: content
+  field_language_toggle:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 11
+    region: content
+  langcode:
+    type: language
+    label: above
+    settings:
+      link_to_entity: false
+      native_language: false
+    third_party_settings: {  }
+    weight: 10
+    region: content
   links:
     settings: {  }
     third_party_settings: {  }
     weight: 0
     region: content
-hidden:
-  langcode: true
+hidden: {  }

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_benefit.teaser.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_benefit.teaser.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.bears_benefit.field_b_source_link
     - field.field.node.bears_benefit.field_b_summary
     - field.field.node.bears_benefit.field_b_tags
+    - field.field.node.bears_benefit.field_language_toggle
     - node.type.bears_benefit
   module:
     - user
@@ -35,4 +36,5 @@ hidden:
   field_b_source_link: true
   field_b_summary: true
   field_b_tags: true
+  field_language_toggle: true
   langcode: true

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_criteria.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_criteria.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.bears_criteria.field_b_name
     - field.field.node.bears_criteria.field_b_type
     - field.field.node.bears_criteria.field_b_values
+    - field.field.node.bears_criteria.field_language_toggle
     - node.type.bears_criteria
   module:
     - options
@@ -25,7 +26,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 107
+    weight: 6
     region: content
   field_b_criteria_key:
     type: string
@@ -33,7 +34,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 102
+    weight: 1
     region: content
   field_b_has_child:
     type: boolean
@@ -43,7 +44,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 106
+    weight: 5
     region: content
   field_b_id:
     type: string
@@ -51,7 +52,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 108
+    weight: 7
     region: content
   field_b_label:
     type: string
@@ -59,7 +60,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 103
+    weight: 2
     region: content
   field_b_name:
     type: string
@@ -67,14 +68,14 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 109
+    weight: 8
     region: content
   field_b_type:
     type: list_default
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 104
+    weight: 3
     region: content
   field_b_values:
     type: string
@@ -82,12 +83,28 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 105
+    weight: 4
+    region: content
+  field_language_toggle:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 10
+    region: content
+  langcode:
+    type: language
+    label: above
+    settings:
+      link_to_entity: false
+      native_language: false
+    third_party_settings: {  }
+    weight: 9
     region: content
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 100
+    weight: 0
     region: content
-hidden:
-  langcode: true
+hidden: {  }

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_criteria.teaser.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_criteria.teaser.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.bears_criteria.field_b_name
     - field.field.node.bears_criteria.field_b_type
     - field.field.node.bears_criteria.field_b_values
+    - field.field.node.bears_criteria.field_language_toggle
     - node.type.bears_criteria
   module:
     - user
@@ -33,4 +34,5 @@ hidden:
   field_b_name: true
   field_b_type: true
   field_b_values: true
+  field_language_toggle: true
   langcode: true

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_life_event.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_life_event.default.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - field.field.node.bears_life_event.field_b_id
     - field.field.node.bears_life_event.field_json_data_file
+    - field.field.node.bears_life_event.field_language_toggle
     - field.field.node.bears_life_event.field_summary
     - node.type.bears_life_event
   module:
@@ -20,7 +21,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 104
+    weight: 3
     region: content
   field_json_data_file:
     type: file_default
@@ -28,19 +29,35 @@ content:
     settings:
       use_description_as_link_text: true
     third_party_settings: {  }
-    weight: 103
+    weight: 2
+    region: content
+  field_language_toggle:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 5
     region: content
   field_summary:
     type: basic_string
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 102
+    weight: 1
+    region: content
+  langcode:
+    type: language
+    label: above
+    settings:
+      link_to_entity: false
+      native_language: false
+    third_party_settings: {  }
+    weight: 4
     region: content
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 100
+    weight: 0
     region: content
-hidden:
-  langcode: true
+hidden: {  }

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_life_event.teaser.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_life_event.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.bears_life_event.field_b_id
     - field.field.node.bears_life_event.field_json_data_file
+    - field.field.node.bears_life_event.field_language_toggle
     - field.field.node.bears_life_event.field_summary
     - node.type.bears_life_event
   module:
@@ -22,5 +23,6 @@ content:
 hidden:
   field_b_id: true
   field_json_data_file: true
+  field_language_toggle: true
   field_summary: true
   langcode: true

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_life_event_form.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_life_event_form.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.bears_life_event_form.field_b_summary
     - field.field.node.bears_life_event_form.field_b_time_estimate
     - field.field.node.bears_life_event_form.field_b_title_prefix
+    - field.field.node.bears_life_event_form.field_language_toggle
     - node.type.bears_life_event_form
   module:
     - entity_reference_revisions
@@ -65,10 +66,26 @@ content:
     third_party_settings: {  }
     weight: 1
     region: content
-  links:
-    settings: {  }
+  field_language_toggle:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 8
+    region: content
+  langcode:
+    type: language
+    label: above
+    settings:
+      link_to_entity: false
+      native_language: false
     third_party_settings: {  }
     weight: 7
     region: content
-hidden:
-  langcode: true
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 6
+    region: content
+hidden: {  }

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_life_event_form.teaser.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_life_event_form.teaser.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.bears_life_event_form.field_b_summary
     - field.field.node.bears_life_event_form.field_b_time_estimate
     - field.field.node.bears_life_event_form.field_b_title_prefix
+    - field.field.node.bears_life_event_form.field_language_toggle
     - node.type.bears_life_event_form
   module:
     - user
@@ -29,4 +30,5 @@ hidden:
   field_b_summary: true
   field_b_time_estimate: true
   field_b_title_prefix: true
+  field_language_toggle: true
   langcode: true

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_agency.field_language_toggle.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_agency.field_language_toggle.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_language_toggle
+    - node.type.bears_agency
+id: node.bears_agency.field_language_toggle
+field_name: field_language_toggle
+entity_type: node
+bundle: bears_agency
+label: 'Language Toggle'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      bears_agency: bears_agency
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_benefit.field_language_toggle.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_benefit.field_language_toggle.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_language_toggle
+    - node.type.bears_benefit
+id: node.bears_benefit.field_language_toggle
+field_name: field_language_toggle
+entity_type: node
+bundle: bears_benefit
+label: 'Language Toggle'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      bears_benefit: bears_benefit
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_criteria.field_language_toggle.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_criteria.field_language_toggle.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_language_toggle
+    - node.type.bears_criteria
+id: node.bears_criteria.field_language_toggle
+field_name: field_language_toggle
+entity_type: node
+bundle: bears_criteria
+label: 'Language Toggle'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      bears_criteria: bears_criteria
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_life_event.field_language_toggle.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_life_event.field_language_toggle.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_language_toggle
+    - node.type.bears_life_event
+id: node.bears_life_event.field_language_toggle
+field_name: field_language_toggle
+entity_type: node
+bundle: bears_life_event
+label: 'Language Toggle'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      bears_life_event: bears_life_event
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_life_event_form.field_language_toggle.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_life_event_form.field_language_toggle.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_language_toggle
+    - node.type.bears_life_event_form
+id: node.bears_life_event_form.field_language_toggle
+field_name: field_language_toggle
+entity_type: node
+bundle: bears_life_event_form
+label: 'Language Toggle'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      bears_life_event_form: bears_life_event_form
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_language_toggle.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_language_toggle.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_language_toggle
+field_name: field_language_toggle
+entity_type: node
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
## PR Summary

This work adds language toggle field in benefit content types.

## Related Github Issue

- fixes #243

## Detailed Testing steps

In sandbox or local server:

- [x] navigate to add or edit form of Agency. see Language Toggle field.
- [x] navigate to add or edit form of Criteria. see Language Toggle field.
- [x] navigate to add or edit form of Benefit. see Language Toggle field.
- [x] navigate to add or edit form of Life Event. see Language Toggle field.
- [x] navigate to add or edit form of Life Event Form. see Language Toggle field.