### PR TITLE
Save JSON data file

### DIFF
--- a/usagov_bears/modules/usagov_bears_api/usagov_bears_api.routing.yml
+++ b/usagov_bears/modules/usagov_bears_api/usagov_bears_api.routing.yml
@@ -10,3 +10,15 @@ usagov_bears_api.life_event:
     parameters:
       id:
         type: string
+usagov_bears_api.life_event_json_file:
+  path: '/bears/api/life-event/{id}/jsonfile'
+  defaults:
+    _controller: '\Drupal\usagov_bears_api\Controller\LifeEventController:saveJsonData'
+    _title: 'USAgov bears JSON file of life event'
+  methods: [GET]
+  requirements:
+    _access: 'TRUE'
+  options:
+    parameters:
+      id:
+        type: string


### PR DESCRIPTION
## PR Summary

This work adds function to save JSON data file.

## Related Github Issue

- fixes #125

## Detailed Testing steps

To test in sandbox or local site.

navigate to http://website/bears/api/life-event/{id}/jsonfile
The id is the ID of life event form, for example death.
- [ ] It builds JSON data.
- [ ] it saves JSON data file, and displays the file location.
For example, the JSON data file is saved to /sites/default/files/bears/api/life_event/death.json
{"data":"Saved JSON data to \/sites\/default\/files\/bears\/api\/life_event\/death.json","method":"GET","status":200}
- [ ] navigates to  http://website/sites/default/files/bears/api/life_event/death.json to view the JSON data.