### PR TITLE
296 child criteria

### DIFF
--- a/bears-app/src/App/__tests__/__snapshots__/index.spec.js.snap
+++ b/bears-app/src/App/__tests__/__snapshots__/index.spec.js.snap
@@ -18,7 +18,7 @@ exports[`App renders a match to the previous snapshot 1`] = `
       <div
         dangerouslySetInnerHTML={
           Object {
-            "__html": "<p>Find government survivor benefits including funeral benefits, housing, and education help.</p>",
+            "__html": "<p>Find government benefits after the loss of a loved one including funeral, housing, and education help.</p>",
           }
         }
       />

--- a/bears-app/src/shared/api/mock-data/current.js
+++ b/bears-app/src/shared/api/mock-data/current.js
@@ -5,7 +5,7 @@ const content = `{
       "timeEstimate": "60 minutes",
       "titlePrefix": "",
       "title": "Find federal benefits after the loss of a loved one",
-      "summary": "<p>Find government survivor benefits including funeral benefits, housing, and education help.</p>",
+      "summary": "<p>Find government benefits after the loss of a loved one including funeral, housing, and education help.</p>",
       "sectionsEligibilityCriteria": [
         {
           "section": {
@@ -123,134 +123,126 @@ const content = `{
               },
               {
                 "fieldset": {
-                  "heading": "Answer yes or no",
-                  "description": "",
-                  "fieldsets": [
+                  "criteriaKey": "applicant_citizen_status",
+                  "legend": "Are you a U.S. citizen or eligible non-citizen?",
+                  "required": "FALSE",
+                  "hint": "",
+                  "inputs": [
                     {
-                      "fieldset": {
-                        "criteriaKey": "applicant_care_for_child",
-                        "legend": "Are you caring for a child of the deceased who is disabled or under the age of 16?",
-                        "required": "FALSE",
-                        "hint": "",
-                        "inputs": [
+                      "inputCriteria": {
+                        "id": "applicant_citizen_status",
+                        "type": "Radio",
+                        "name": "applicant_citizen_status",
+                        "label": "Are you a U.S. citizen or eligible non-citizen?",
+                        "hasChild": "FALSE",
+                        "childDependencyOption": "",
+                        "values": [
                           {
-                            "inputCriteria": {
-                              "id": "applicant_care_for_child",
-                              "type": "Radio",
-                              "name": "applicant_care_for_child",
-                              "label": "Are you caring for a child of someone who is retired, has a disability, or has died, and the child is disabled or under the age of 16?",
-                              "hasChild": "FALSE",
-                              "childDependencyOption": "",
-                              "values": [
-                                {
-                                  "option": "Yes",
-                                  "value": "Yes"
-                                },
-                                {
-                                  "option": "No",
-                                  "value": "No"
-                                }
-                              ]
-                            }
-                          }
-                        ],
-                        "children": []
-                      }
-                    },
-                    {
-                      "fieldset": {
-                        "criteriaKey": "applicant_paid_funeral_expenses",
-                        "legend": "Did you pay for funeral or burial expenses?",
-                        "required": "FALSE",
-                        "hint": "",
-                        "inputs": [
+                            "option": "Yes",
+                            "value": "Yes"
+                          },
                           {
-                            "inputCriteria": {
-                              "id": "applicant_paid_funeral_expenses",
-                              "type": "Select",
-                              "name": "applicant_paid_funeral_expenses",
-                              "label": "Did you pay for funeral or burial expenses?",
-                              "hasChild": "FALSE",
-                              "childDependencyOption": "",
-                              "values": [
-                                {
-                                  "option": "Yes",
-                                  "value": "Yes"
-                                },
-                                {
-                                  "option": "No",
-                                  "value": "No"
-                                }
-                              ]
-                            }
+                            "option": "No",
+                            "value": "No"
                           }
-                        ],
-                        "children": []
-                      }
-                    },
-                    {
-                      "fieldset": {
-                        "criteriaKey": "applicant_funeral_reimbursement",
-                        "legend": "Did any organization or government agency reimburse you for any funeral or burial expenses?",
-                        "required": "FALSE",
-                        "hint": "",
-                        "inputs": [
-                          {
-                            "inputCriteria": {
-                              "id": "applicant_funeral_reimbursement",
-                              "type": "Radio",
-                              "name": "applicant_funeral_reimbursment",
-                              "label": "Did any organization or government agency reimburse you for any funeral or burial expenses?",
-                              "hasChild": "FALSE",
-                              "childDependencyOption": "",
-                              "values": [
-                                {
-                                  "option": "Yes",
-                                  "value": "Yes"
-                                },
-                                {
-                                  "option": "No",
-                                  "value": "No"
-                                }
-                              ]
-                            }
-                          }
-                        ],
-                        "children": []
-                      }
-                    },
-                    {
-                      "fieldset": {
-                        "criteriaKey": "applicant_citizen_status",
-                        "legend": "Are you a U.S. citizen or eligible non-citizen?",
-                        "required": "FALSE",
-                        "hint": "",
-                        "inputs": [
-                          {
-                            "inputCriteria": {
-                              "id": "applicant_citizen_status",
-                              "type": "Radio",
-                              "name": "applicant_citizen_status",
-                              "label": "Are you a U.S. citizen or eligible non-citizen?",
-                              "hasChild": "FALSE",
-                              "childDependencyOption": "",
-                              "values": [
-                                {
-                                  "option": "Yes",
-                                  "value": "Yes"
-                                },
-                                {
-                                  "option": "No",
-                                  "value": "No"
-                                }
-                              ]
-                            }
-                          }
-                        ],
-                        "children": []
+                        ]
                       }
                     }
-                  ]
+                  ],
+                  "children": []
+                }
+              },
+              {
+                "fieldset": {
+                  "criteriaKey": "applicant_care_for_child",
+                  "legend": "Are you caring for a child of the deceased who is disabled or under the age of 16?",
+                  "required": "FALSE",
+                  "hint": "",
+                  "inputs": [
+                    {
+                      "inputCriteria": {
+                        "id": "applicant_care_for_child",
+                        "type": "Radio",
+                        "name": "applicant_care_for_child",
+                        "label": "Are you caring for a child of someone who is retired, has a disability, or has died, and the child is disabled or under the age of 16?",
+                        "hasChild": "FALSE",
+                        "childDependencyOption": "",
+                        "values": [
+                          {
+                            "option": "Yes",
+                            "value": "Yes"
+                          },
+                          {
+                            "option": "No",
+                            "value": "No"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "children": []
+                }
+              },
+              {
+                "fieldset": {
+                  "criteriaKey": "applicant_paid_funeral_expenses",
+                  "legend": "Did you pay for funeral or burial expenses?",
+                  "required": "FALSE",
+                  "hint": "",
+                  "inputs": [
+                    {
+                      "inputCriteria": {
+                        "id": "applicant_paid_funeral_expenses",
+                        "type": "Radio",
+                        "name": "applicant_paid_funeral_expenses",
+                        "label": "Did you pay for funeral or burial expenses?",
+                        "hasChild": "FALSE",
+                        "childDependencyOption": "",
+                        "values": [
+                          {
+                            "option": "Yes",
+                            "value": "Yes"
+                          },
+                          {
+                            "option": "No",
+                            "value": "No"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "children": []
+                }
+              },
+              {
+                "fieldset": {
+                  "criteriaKey": "applicant_funeral_reimbursement",
+                  "legend": "Did you pay for funeral or burial expenses?",
+                  "required": "FALSE",
+                  "hint": "",
+                  "inputs": [
+                    {
+                      "inputCriteria": {
+                        "id": "applicant_funeral_reimbursement",
+                        "type": "Radio",
+                        "name": "applicant_funeral_reimbursment",
+                        "label": "Did any organization or government agency reimburse you for any funeral or burial expenses?",
+                        "hasChild": "FALSE",
+                        "childDependencyOption": "",
+                        "values": [
+                          {
+                            "option": "Yes",
+                            "value": "Yes"
+                          },
+                          {
+                            "option": "No",
+                            "value": "No"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "children": []
                 }
               }
             ]
@@ -411,7 +403,7 @@ const content = `{
               {
                 "fieldset": {
                   "criteriaKey": "deceased_miner",
-                  "legend": "",
+                  "legend": "Did the person work in the coal mines and their death was due to black lung disease (pneumoconiosis)?",
                   "required": "FALSE",
                   "hint": "",
                   "inputs": [
@@ -514,8 +506,8 @@ const content = `{
                         "type": "Radio",
                         "name": "deceased_served_in_active_military",
                         "label": "Did the deceased serve in active military service?",
-                        "hasChild": "FALSE",
-                        "childDependencyOption": "",
+                        "hasChild": "TRUE",
+                        "childDependencyOption": "Yes",
                         "values": [
                           {
                             "option": "Yes",
@@ -535,7 +527,7 @@ const content = `{
                         {
                           "fieldset": {
                             "criteriaKey": "deceased_service_status",
-                            "legend": "",
+                            "legend": "What was the service status of the deceased?",
                             "required": "FALSE",
                             "hint": "",
                             "inputs": [
@@ -568,91 +560,89 @@ const content = `{
                                 }
                               }
                             ],
-                            "children": [
+                            "children": []
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "fieldsets": [
+                        {
+                          "fieldset": {
+                            "criteriaKey": "deceased_military_death_circumstance",
+                            "legend": "Which option applies to the deceased?",
+                            "required": "FALSE",
+                            "hint": "",
+                            "inputs": [
                               {
-                                "fieldsets": [
-                                  {
-                                    "fieldset": {
-                                      "criteriaKey": "deceased_military_death_circumstance",
-                                      "legend": "",
-                                      "required": "FALSE",
-                                      "hint": "",
-                                      "inputs": [
-                                        {
-                                          "inputCriteria": {
-                                            "id": "deceased_military_death_circumstance",
-                                            "type": "Radio",
-                                            "name": "deceased_military_death_circumstance",
-                                            "label": "Which option applies to the deceased?",
-                                            "hasChild": "FALSE",
-                                            "childDependencyOption": "",
-                                            "values": [
-                                              {
-                                                "option": "Died while on active duty",
-                                                "value": "Died while on active duty"
-                                              },
-                                              {
-                                                "option": "Died while on inactive-duty training",
-                                                "value": "Died while on inactive-duty training"
-                                              },
-                                              {
-                                                "option": "Died as a result of a service-related disability/illness",
-                                                "value": "Died as a result of a service-related disability/illness"
-                                              },
-                                              {
-                                                "option": "Died while receiving/traveling to VA care",
-                                                "value": "Died while receiving/traveling to VA care"
-                                              },
-                                              {
-                                                "option": "Died while receiving/eligible for VA compensation",
-                                                "value": "Died while receiving/eligible for VA compensation"
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      ],
-                                      "children": [
-                                        {
-                                          "fieldsets": [
-                                            {
-                                              "fieldset": {
-                                                "criteriaKey": "deceased_grave_headstone",
-                                                "legend": "",
-                                                "required": "FALSE",
-                                                "hint": "",
-                                                "inputs": [
-                                                  {
-                                                    "inputCriteria": {
-                                                      "id": "deceased_grave_headstone",
-                                                      "type": "Radio",
-                                                      "name": "deceased_grave_headstone",
-                                                      "label": "Is the person buried in a grave with a privately purchased headstone or in an unmarked grave?",
-                                                      "hasChild": "FALSE",
-                                                      "childDependencyOption": "",
-                                                      "values": [
-                                                        {
-                                                          "option": "Yes",
-                                                          "value": "Yes"
-                                                        },
-                                                        {
-                                                          "option": "No",
-                                                          "value": "No"
-                                                        }
-                                                      ]
-                                                    }
-                                                  }
-                                                ],
-                                                "children": []
-                                              }
-                                            }
-                                          ]
-                                        }
-                                      ]
+                                "inputCriteria": {
+                                  "id": "deceased_military_death_circumstance",
+                                  "type": "Radio",
+                                  "name": "deceased_military_death_circumstance",
+                                  "label": "Which option applies to the deceased?",
+                                  "hasChild": "FALSE",
+                                  "childDependencyOption": "",
+                                  "values": [
+                                    {
+                                      "option": "Died while on active duty",
+                                      "value": "Died while on active duty"
+                                    },
+                                    {
+                                      "option": "Died while on inactive-duty training",
+                                      "value": "Died while on inactive-duty training"
+                                    },
+                                    {
+                                      "option": "Died as a result of a service-related disability/illness",
+                                      "value": "Died as a result of a service-related disability/illness"
+                                    },
+                                    {
+                                      "option": "Died while receiving/traveling to VA care",
+                                      "value": "Died while receiving/traveling to VA care"
+                                    },
+                                    {
+                                      "option": "Died while receiving/eligible for VA compensation",
+                                      "value": "Died while receiving/eligible for VA compensation"
                                     }
-                                  }
-                                ]
+                                  ]
+                                }
                               }
-                            ]
+                            ],
+                            "children": []
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "fieldsets": [
+                        {
+                          "fieldset": {
+                            "criteriaKey": "deceased_grave_headstone",
+                            "legend": "Is the person buried in a grave with a privately purchased headstone or an unmarked grave?",
+                            "required": "FALSE",
+                            "hint": "",
+                            "inputs": [
+                              {
+                                "inputCriteria": {
+                                  "id": "deceased_grave_headstone",
+                                  "type": "Radio",
+                                  "name": "deceased_grave_headstone",
+                                  "label": "Is the person buried in a grave with a privately purchased headstone or in an unmarked grave?",
+                                  "hasChild": "FALSE",
+                                  "childDependencyOption": "",
+                                  "values": [
+                                    {
+                                      "option": "Yes",
+                                      "value": "Yes"
+                                    },
+                                    {
+                                      "option": "No",
+                                      "value": "No"
+                                    }
+                                  ]
+                                }
+                              }
+                            ],
+                            "children": []
                           }
                         }
                       ]
@@ -668,8 +658,304 @@ const content = `{
     "benefits": [
       {
         "benefit": {
+          "title": "Burial benefits",
+          "summary": "<p>Burial and transport assistance for the deceased, and travel support for the spouse, children, and immediate family members of the service member.</p>",
+          "SourceLink": "https://www.dcms.uscg.mil/Portals/10/CG-1/PSC/PSD/docs/SurvivorsGuide2015.pdf?ver=2017-03-24-132033-397",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Department of Defense (DOD)",
+            "summary": "<p>Provides support for qualified spouses, children, and other family members of deceased service members.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty member",
+              "acceptableValues": [
+                "Active-duty member"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died on active duty",
+              "acceptableValues": [
+                "Died on active duty"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Applicant's relationship to the deceased is: spouse, child, parent, or other family member",
+              "acceptableValues": [
+                "Spouse",
+                "Child",
+                "Parent",
+                "Other family member"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Death gratuity",
+          "summary": "<p>Tax free payment of $100,000 to eligible survivors of members of the Armed Forces who died while on active duty or while serving in certain reserve statuses.</p>",
+          "SourceLink": "https://militarypay.defense.gov/Benefits/Death-Gratuity/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Department of Defense (DOD)",
+            "summary": "<p>Provides support for qualified spouses, children, and other family members of deceased service members.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member or member of the National Guard/Reserves",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Member of the National Guard/Reserves"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died while on active duty or Died while on inactive-duty service training",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died while on inactive-duty service training"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
+              "acceptableValues": [
+                "Spouse",
+                "Child",
+                "Parent",
+                "Other family member"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Burial flag",
+          "summary": "<p>A United States flag for the coffin or urn in honor of the military service member.</p>",
+          "SourceLink": "https://www.va.gov/burials-memorials/memorial-items/burial-flags/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "The deceased served in the active military"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, or member of the National Guard/Reserves ",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable",
+                "Member of the National Guard/Reserves"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
+              "acceptableValues": [
+                "Spouse",
+                "Child",
+                "Parent",
+                "Other family member"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Annuity for Certain Military Surviving Spouses",
+          "summary": "<p>Financial support for surviving spouses of members of the uniformed services.</p>",
+          "SourceLink": "https://militarypay.defense.gov/Benefits/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Department of Defense (DOD)",
+            "summary": "<p>Provides support for qualified spouses, children, and other family members of deceased service members.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_date_of_death",
+              "label": "Deceased died before 1978",
+              "acceptableValues": [
+                "<01-01-1978"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "You served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: retired from the service",
+              "acceptableValues": [
+                "Retired from the service"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse",
+              "acceptableValues": [
+                "Spouse"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Burial in VA national cemetery",
+          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->Veterans, service members, and some family members may be eligible for burial in VA national cemeteries.</p>",
+          "SourceLink": "https://www.va.gov/burials-memorials/eligibility/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, or member of the National Guard/Reserves",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable",
+                "Member of the National Guard/Reserves"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, died while receiving/traveling to VA care, or died while receiving/eligible for VA compensation",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died as a result of a service-related disability/illness",
+                "Died while receiving/traveling to VA care",
+                "Died while receiving/eligible for VA compensation"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Civilian Health and Medical Program of the VA (CHAMPVA) for child",
+          "summary": "<p>Health insurance for dependents and surviving spouses covering some health care services and supplies.</p>",
+          "SourceLink": "https://www.va.gov/health-care/family-caregiver-benefits/champva/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member or discharged under conditions other than dishonorable",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died while on active duty or died as a result of a service-related disability/illness",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died as a result of a service-related disability/illness"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_date_of_birth",
+              "label": "You are under 18 years",
+              "acceptableValues": [
+                "<18years"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is: unmarried ",
+              "acceptableValues": [
+                "Unmarried"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: child",
+              "acceptableValues": [
+                "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
           "title": "COVID-19 funeral assistance",
-          "summary": "<p>Financial assistance to coversome burial and funeral costs for people who died of COVID-19.</p>",
+          "summary": "<p>Financial assistance for burial and funeral costs for someone who died of COVID-19. To be eligible, you were not reimbursed from an organization or agency.</p>",
           "SourceLink": "https://www.fema.gov/disasters/coronavirus/economic/funeral-assistance",
           "SourceIsEnglish": "FALSE",
           "agency": {
@@ -711,9 +997,375 @@ const content = `{
             },
             {
               "criteriaKey": "applicant_paid_funeral_expenses",
-              "label": "You paid for funeral/burial expenses and were not reimbursed by any organization or agency",
+              "label": "You paid for funeral or burial expenses and were not reimbursed",
               "acceptableValues": [
                 "Yes"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Dependency and Indemnity Compensation (DIC) for child",
+          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->Tax-free financial assistance to surviving children or family members of service members and veterans.</p>",
+          "SourceLink": "https://www.va.gov/disability/dependency-indemnity-compensation/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "Did the deceased serve in the active military, naval, or air service?",
+              "acceptableValues": [
+                "You served in the active military"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member or discharged under conditions other than dishonorable",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, or died while receiving/eligible for VA compensation",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died as a result of a service-related disability/illness",
+                "Died while receiving/eligible for VA compensation"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_date_of_birth",
+              "label": "You are under 18 years",
+              "acceptableValues": [
+                "<18years"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is: unmarried",
+              "acceptableValues": [
+                "Unmarried"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: child",
+              "acceptableValues": [
+                "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Dependency and Indemnity Compensation (DIC) for parent",
+          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->Tax-free financial assistance to surviving parents or family members of service members and veterans.</p>",
+          "SourceLink": "https://www.va.gov/disability/dependency-indemnity-compensation/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member or discharged under conditions other than dishonorable",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, or died while receiving/eligible for VA compensation",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died as a result of a service-related disability/illness",
+                "Died while receiving/eligible for VA compensation"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_income",
+              "label": "You have limited income and resources",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: parent",
+              "acceptableValues": [
+                "Parent"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Dependency and Indemnity Compensation (DIC) for spouse",
+          "summary": "<p>Tax-free financial assistance to surviving spouses or family members of service members or veterans.</p>",
+          "SourceLink": "https://www.va.gov/disability/dependency-indemnity-compensation/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "Did the deceased serve in the active military, naval, or air service?",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "What was the service status of the deceased?",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "Which option applies to the deceased?",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died as a result of a service-related disability/illness",
+                "Died while receiving/eligible for VA compensation"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Marital status",
+              "acceptableValues": [
+                "Unmarried",
+                "Widowed"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Applicant's relationship to the deceased:",
+              "acceptableValues": [
+                "Spouse"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Education benefits (GI Bill) for survivors",
+          "summary": "<p>VA education benefits or job training for dependents and survivors of a veteran.</p>",
+          "SourceLink": "https://www.va.gov/education/survivor-dependent-benefits/",
+          "SourceIsEnglish": "FALSE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: Active-duty service member or discharged under conditions other than dishonorable",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died while on active duty or died as a result of a service-related disability/illness",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died as a result of a service-related disability/illness"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_high-school_diploma",
+              "label": "You have a high school diploma or GED certificate",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse or child",
+              "acceptableValues": [
+                "Spouse",
+                "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Financial Assistance and Social Services (FASS)",
+          "summary": "<p>Assistance with burial expenses of deceased indigent Indians who do not have resources for funeral expenses.</p>",
+          "SourceLink": "https://www.bia.gov/bia/ois/dhs/financial-assistance",
+          "SourceIsEnglish": "FALSE",
+          "agency": {
+            "title": "Department of Interior (DOI) - Indian Affairs",
+            "summary": "<p>The Bureau of Indian Affairs enhances the quality of life and protects and improves the trust assets of American Indians, Indian tribes, and Alaska Natives.</p>",
+            "lede": "<p>The Bureau of Indian Affairs enhances the quality of life and protects and improves the trust assets of American Indians, Indian tribes, and Alaska Natives.</p>"
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_american_indian",
+              "label": "The deceased was a member of a federally recognized American Indian Tribe or an Alaska Native.",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_income",
+              "label": "You have limited income and resources",
+              "acceptableValues": [
+                "Yes"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Home loan program for survivors",
+          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->VA-backed home loan to surviving spouses of veterans.</p>",
+          "SourceLink": "https://www.va.gov/housing-assistance/home-loans/surviving-spouse/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is:",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, Died while receiving/traveling to VA care, or died while receiving/eligible for VA compensation",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died as a result of a service-related disability/illness",
+                "Died while receiving/traveling to VA care",
+                "Died while receiving/eligible for VA compensation"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is widowed",
+              "acceptableValues": [
+                "Widowed"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse",
+              "acceptableValues": [
+                "Spouse"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Life insurance for survivors of veterans",
+          "summary": "<p>Payment from a veteran's or service member's life insurance policy.</p>",
+          "SourceLink": "https://www.benefits.va.gov/INSURANCE/sglivgli.asp",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, retired from the service, or member of the National Guard/Reserves",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable",
+                "Retired from the service",
+                "Member of the National Guard/Reserves"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
+              "acceptableValues": [
+                "Spouse",
+                "Child",
+                "Parent",
+                "Other family member"
               ]
             }
           ]
@@ -761,6 +1413,887 @@ const content = `{
               "acceptableValues": [
                 "Spouse",
                 "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Presidential Memorial Certificate",
+          "summary": "<p>An engraved Presidential Memorial Certificate (PMC) signed by the current president honoring the military service of a veteran or reservist.</p>",
+          "SourceLink": "https://www.va.gov/burials-memorials/memorial-items/presidential-memorial-certificates/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, or member of the National Guard/Reserves",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable",
+                "Member of the National Guard/Reserves"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, died while receiving/traveling to VA care, or died while receiving/eligible for VA compensation",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died as a result of a service-related disability/illness",
+                "Died while receiving/traveling to VA care",
+                "Died while receiving/eligible for VA compensation"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
+              "acceptableValues": [
+                "Spouse",
+                "Child",
+                "Parent",
+                "Other family member"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Public Safety Officers' Death Benefits",
+          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->A one-time benefit for survivors of law enforcement officers, firefighters, and other first responders whose deaths were the result of an injury sustained in the line of duty.</p>",
+          "SourceLink": "https://psob.bja.ojp.gov/PSOB_FactSheet2019.pdf",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Department of Justice (DOJ)",
+            "summary": "<p>Offers financial and educational support to help families of fallen public safety officers.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_public_safety_officer",
+              "label": "The deceased was a public safety officer who died in the line of duty",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
+              "acceptableValues": [
+                "Spouse",
+                "Child",
+                "Parent",
+                "Other family member"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Public Safety Officers' Educational Assistance Program",
+          "summary": "<p>Financial assistance for higher education to spouses and children of police, fire, and emergency public safety officers killed in the line of duty.</p>",
+          "SourceLink": "https://psob.bja.ojp.gov/PSOB_Education2018.pdf",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Department of Justice (DOJ)",
+            "summary": "<p>Offers financial and educational support to help families of fallen public safety officers.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_public_safety_officer",
+              "label": "The deceased was a public safety officer who died in the line of duty",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse or child",
+              "acceptableValues": [
+                "Spouse",
+                "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivor benefit plan",
+          "summary": "<p>Up to 55% of a service member's retired pay for survivors of active duty service members and some retired and reserve members.</p>",
+          "SourceLink": "https://militarypay.defense.gov/Benefits/Survivor-Benefit-Program/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Department of Defense (DOD)",
+            "summary": "<p>Provides support for qualified spouses, children, and other family members of deceased service members.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member, retired from the service, or member of the National Guard/Reserves",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Retired from the service",
+                "Member of the National Guard/Reserves"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died while on active duty or died while on inactive-duty service training",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died while on inactive-duty service training"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse or child",
+              "acceptableValues": [
+                "Spouse",
+                "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivors benefits for child",
+          "summary": "<p>Social Security survivors benefits paid to a child, stepchild, grandchild, or adopted child of eligible workers.</p>",
+          "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h4",
+          "SourceIsEnglish": "FALSE",
+          "agency": {
+            "title": "Social Security Administration (SSA)",
+            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_paid_into_SS",
+              "label": "The deceased worked and paid Social Security taxes",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_date_of_birth",
+              "label": "You are under 18 years",
+              "acceptableValues": [
+                "<18years"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is unmarried",
+              "acceptableValues": [
+                "Unmarried"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_citizen_status",
+              "label": "You are a U.S. citizen or eligible non-citizen",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Applicant's relationship to the deceased is: child",
+              "acceptableValues": [
+                "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivors benefits for child with disabilities",
+          "summary": "<p>Social Security survivors benefits to a child, stepchild, grandchild, or adopted child with disabilities of eligible workers.</p>",
+          "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h4",
+          "SourceIsEnglish": "FALSE",
+          "agency": {
+            "title": "Social Security Administration (SSA)",
+            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_paid_into_SS",
+              "label": "The deceased worked and paid Social Security taxes",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_date_of_birth",
+              "label": "You are under 18 years",
+              "acceptableValues": [
+                "<18years"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is unmarried",
+              "acceptableValues": [
+                "Unmarried"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_citizen_status",
+              "label": "You are a U.S. citizen or eligible non-citizen",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_disability",
+              "label": "You have a disability",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_ability_to_work",
+              "label": "You are unable to work for a year or more because of a disability or your disability is expected to result in death",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: child",
+              "acceptableValues": [
+                "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivors benefits for mothers/fathers",
+          "summary": "<p>Social Security survivors benefits to the person providing care for the child of a deceased worker.</p>",
+          "SourceLink": "https://www.ssa.gov/forms/ssa-5.html",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Social Security Administration (SSA)",
+            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_paid_into_SS",
+              "label": "The deceased worked and paid Social Security taxes",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is unmarried or widowed",
+              "acceptableValues": [
+                "Unmarried",
+                "Widowed"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_citizen_status",
+              "label": "You are a US citizen or eligible non-citizen",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_care_for_child",
+              "label": "You are caring for a child of someone who is retired, has a disability, or has died, and the child is disabled or under the age of 16",
+              "acceptableValues": [
+                "Yes"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivors benefits for parents",
+          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->Social Security survivors benefits to parents of eligible workers.</p>",
+          "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h5",
+          "SourceIsEnglish": "FALSE",
+          "agency": {
+            "title": "Social Security Administration (SSA)",
+            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_paid_into_SS",
+              "label": "The deceased worked and paid Social Security taxes",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_date_of_birth",
+              "label": "You are over 62 years",
+              "acceptableValues": [
+                ">=62years"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_citizen_status",
+              "label": "You are a US citizen or eligible non-citizen",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: parent",
+              "acceptableValues": [
+                "Parent"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivors benefits for spouse",
+          "summary": "<p>Social Security survivors benefits to surviving spouses and certain divorced spouses of eligible workers.</p>",
+          "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h2",
+          "SourceIsEnglish": "FALSE",
+          "agency": {
+            "title": "Social Security Administration (SSA)",
+            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_paid_into_SS",
+              "label": "The deceased worked and paid Social Security taxes",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_date_of_birth",
+              "label": "You are over 60 years",
+              "acceptableValues": [
+                ">=60years"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is widowed or divorced",
+              "acceptableValues": [
+                "Widowed",
+                "Divorced"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_citizen_status",
+              "label": "You are a US citizen or eligible non-citizen",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse",
+              "acceptableValues": [
+                "Spouse"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivors benefits for spouse with disabilities",
+          "summary": "<p>Social Security survivors benefits to surviving spouses and certain divorced spouses with disabilities of eligible workers.</p>",
+          "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h2",
+          "SourceIsEnglish": "FALSE",
+          "agency": {
+            "title": "Social Security Administration (SSA)",
+            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_paid_into_SS",
+              "label": "Did the deceased ever work and pay Social Security taxes on their earnings?",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_date_of_birth",
+              "label": "You are over 50 years",
+              "acceptableValues": [
+                ">=50years"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is widowed or divorced",
+              "acceptableValues": [
+                "Widowed",
+                "Divorced"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_citizen_status",
+              "label": "You are a US citizen or eligible non-citizen",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_disability",
+              "label": "You have a disability",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_ability_to_work",
+              "label": "You are unable to work for a year or more because of a disability or your disability is expected to result in death",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse",
+              "acceptableValues": [
+                "Spouse"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivors pension for child",
+          "summary": "<p>Monthly payments to qualified unmarried dependent children of deceased wartime veterans.</p>",
+          "SourceLink": "https://www.va.gov/pension/survivors-pension/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "You served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "Your service status is: discharged for conditions other than dishonorable",
+              "acceptableValues": [
+                "Discharged for conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_date_of_birth",
+              "label": "You are under 18 years",
+              "acceptableValues": [
+                "<18years"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is unmarried",
+              "acceptableValues": [
+                "Unmarried"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: child",
+              "acceptableValues": [
+                "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivors pension for child with disabilities",
+          "summary": "<p>Monthly payments to qualified unmarried dependent children with disabilities of wartime veterans with certain income and net worth limits.</p>",
+          "SourceLink": "https://www.va.gov/pension/survivors-pension/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: discharged for conditions other than dishonorable",
+              "acceptableValues": [
+                "Discharged for conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_date_of_birth",
+              "label": "You are under 18 years",
+              "acceptableValues": [
+                ">18years"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is unmarried",
+              "acceptableValues": [
+                "Unmarried"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_disability",
+              "label": "You have a disability",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: child",
+              "acceptableValues": [
+                "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivors pension for spouse",
+          "summary": "<p>Monthly payments to surviving spouses of wartime veterans with certain income and net worth limits.</p>",
+          "SourceLink": "https://www.va.gov/pension/survivors-pension/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: discharged for conditions other than dishonorable",
+              "acceptableValues": [
+                "Discharged for conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is unmarried or widowed",
+              "acceptableValues": [
+                "Unmarried",
+                "Widowed"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_income",
+              "label": "You have limited income and resources",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse",
+              "acceptableValues": [
+                "Spouse"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Veterans burial allowance",
+          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->Assistance with burial, funeral, and transportation costs of a deceased veteran.</p>",
+          "SourceLink": "https://www.va.gov/burials-memorials/veterans-burial-allowance/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_date_of_death",
+              "label": "The deceased died within the last two years",
+              "acceptableValues": [
+                "<2years (The deceased died within the last two years.)"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: discharged for conditions other than dishonorable",
+              "acceptableValues": [
+                "Discharged for conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died as a result of a service-related disability/illness, died while receiving/traveling to VA care, or died while receiving/eligible for VA compensation",
+              "acceptableValues": [
+                "Died as a result of a service-related disability/illness",
+                "Died while receiving/traveling to VA care",
+                "Died while receiving/eligible for VA compensation"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
+              "acceptableValues": [
+                "Spouse",
+                "Child",
+                "Parent",
+                "Other family member"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_paid_funeral_expenses",
+              "label": "You paid for funeral or burial expenses",
+              "acceptableValues": [
+                "Yes"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Veterans headstone and grave marker",
+          "summary": "<p>A headstone, grave or niche marker, or medallion to honor a veteran, service member, or eligible family member.</p>",
+          "SourceLink": "https://www.va.gov/burials-memorials/memorial-items/headstones-markers-medallions/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, or member of the National Guard/Reserves",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable",
+                "Member of the National Guard/Reserves"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_grave_headstone",
+              "label": "The person is buried in a grave with a privately purchased headstone or an unmarked grave",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
+              "acceptableValues": [
+                "Spouse",
+                "Child",
+                "Parent",
+                "Other family member"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Veterans medallion",
+          "summary": "<p>A headstone medallion, grave marker, and Presidential Memorial Certificate for eligible veterans buried in a private cemetery.</p>",
+          "SourceLink": "https://www.va.gov/burials-memorials/memorial-items/headstones-markers-medallions/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, or a member of the National Guard/Reserves",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable",
+                "Member of the National Guard/Reserves"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_grave_headstone",
+              "label": "The person is buried in a grave with a privately purchased headstone or an unmarked grave",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
+              "acceptableValues": [
+                "Spouse",
+                "Child",
+                "Parent",
+                "Other family member"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Coal Mine Workers' Compensation (black lung benefits)",
+          "summary": "<p>Compensation to coal miners who were totally disabled by black lung disease (pneumoconiosis) or surviving spouses of miners whose deaths are attributable to this disease.&nbsp;</p><p>Also provides medical coverage for treatment of related lung diseases.</p>",
+          "SourceLink": "https://www.dol.gov/agencies/owcp/dcmwc/filing_guide_miner",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Department of Labor (DOL)",
+            "summary": "<p>Promotes and improves the welfare, working conditions, opportunities, benefits and rights of wage earners, job seekers, and retirees of the United States.</p>",
+            "lede": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->Promotes and improves the welfare, working conditions, opportunities, benefits and rights of wage earners, job seekers, and retirees of the United States.</p>"
+          },
+          "tags": [
+            "Disability benefits",
+            "Retirement"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "applicant_disability",
+              "label": "Do you have a physical or mental impairment (including an emotional or learning disability)?",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_ability_to_work",
+              "label": "You are unable to work for a year or more because of a disability or your disability is expected to result in death",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_miner",
+              "label": "You worked in the coal mining industry and suffer from an illness caused by black lung disease (pneumoconiosis)",
+              "acceptableValues": [
+                "Yes"
               ]
             }
           ]

--- a/bears-app/src/shared/api/mock-data/current.json
+++ b/bears-app/src/shared/api/mock-data/current.json
@@ -5,7 +5,7 @@
       "timeEstimate": "60 minutes",
       "titlePrefix": "",
       "title": "Find federal benefits after the loss of a loved one",
-      "summary": "<p>Find government survivor benefits including funeral benefits, housing, and education help.</p>",
+      "summary": "<p>Find government benefits after the loss of a loved one including funeral, housing, and education help.</p>",
       "sectionsEligibilityCriteria": [
         {
           "section": {
@@ -123,134 +123,126 @@
               },
               {
                 "fieldset": {
-                  "heading": "Answer yes or no",
-                  "description": "",
-                  "fieldsets": [
+                  "criteriaKey": "applicant_citizen_status",
+                  "legend": "Are you a U.S. citizen or eligible non-citizen?",
+                  "required": "FALSE",
+                  "hint": "",
+                  "inputs": [
                     {
-                      "fieldset": {
-                        "criteriaKey": "applicant_care_for_child",
-                        "legend": "Are you caring for a child of the deceased who is disabled or under the age of 16?",
-                        "required": "FALSE",
-                        "hint": "",
-                        "inputs": [
+                      "inputCriteria": {
+                        "id": "applicant_citizen_status",
+                        "type": "Radio",
+                        "name": "applicant_citizen_status",
+                        "label": "Are you a U.S. citizen or eligible non-citizen?",
+                        "hasChild": "FALSE",
+                        "childDependencyOption": "",
+                        "values": [
                           {
-                            "inputCriteria": {
-                              "id": "applicant_care_for_child",
-                              "type": "Radio",
-                              "name": "applicant_care_for_child",
-                              "label": "Are you caring for a child of someone who is retired, has a disability, or has died, and the child is disabled or under the age of 16?",
-                              "hasChild": "FALSE",
-                              "childDependencyOption": "",
-                              "values": [
-                                {
-                                  "option": "Yes",
-                                  "value": "Yes"
-                                },
-                                {
-                                  "option": "No",
-                                  "value": "No"
-                                }
-                              ]
-                            }
-                          }
-                        ],
-                        "children": []
-                      }
-                    },
-                    {
-                      "fieldset": {
-                        "criteriaKey": "applicant_paid_funeral_expenses",
-                        "legend": "Did you pay for funeral or burial expenses?",
-                        "required": "FALSE",
-                        "hint": "",
-                        "inputs": [
+                            "option": "Yes",
+                            "value": "Yes"
+                          },
                           {
-                            "inputCriteria": {
-                              "id": "applicant_paid_funeral_expenses",
-                              "type": "Select",
-                              "name": "applicant_paid_funeral_expenses",
-                              "label": "Did you pay for funeral or burial expenses?",
-                              "hasChild": "FALSE",
-                              "childDependencyOption": "",
-                              "values": [
-                                {
-                                  "option": "Yes",
-                                  "value": "Yes"
-                                },
-                                {
-                                  "option": "No",
-                                  "value": "No"
-                                }
-                              ]
-                            }
+                            "option": "No",
+                            "value": "No"
                           }
-                        ],
-                        "children": []
-                      }
-                    },
-                    {
-                      "fieldset": {
-                        "criteriaKey": "applicant_funeral_reimbursement",
-                        "legend": "Did any organization or government agency reimburse you for any funeral or burial expenses?",
-                        "required": "FALSE",
-                        "hint": "",
-                        "inputs": [
-                          {
-                            "inputCriteria": {
-                              "id": "applicant_funeral_reimbursement",
-                              "type": "Radio",
-                              "name": "applicant_funeral_reimbursment",
-                              "label": "Did any organization or government agency reimburse you for any funeral or burial expenses?",
-                              "hasChild": "FALSE",
-                              "childDependencyOption": "",
-                              "values": [
-                                {
-                                  "option": "Yes",
-                                  "value": "Yes"
-                                },
-                                {
-                                  "option": "No",
-                                  "value": "No"
-                                }
-                              ]
-                            }
-                          }
-                        ],
-                        "children": []
-                      }
-                    },
-                    {
-                      "fieldset": {
-                        "criteriaKey": "applicant_citizen_status",
-                        "legend": "Are you a U.S. citizen or eligible non-citizen?",
-                        "required": "FALSE",
-                        "hint": "",
-                        "inputs": [
-                          {
-                            "inputCriteria": {
-                              "id": "applicant_citizen_status",
-                              "type": "Radio",
-                              "name": "applicant_citizen_status",
-                              "label": "Are you a U.S. citizen or eligible non-citizen?",
-                              "hasChild": "FALSE",
-                              "childDependencyOption": "",
-                              "values": [
-                                {
-                                  "option": "Yes",
-                                  "value": "Yes"
-                                },
-                                {
-                                  "option": "No",
-                                  "value": "No"
-                                }
-                              ]
-                            }
-                          }
-                        ],
-                        "children": []
+                        ]
                       }
                     }
-                  ]
+                  ],
+                  "children": []
+                }
+              },
+              {
+                "fieldset": {
+                  "criteriaKey": "applicant_care_for_child",
+                  "legend": "Are you caring for a child of the deceased who is disabled or under the age of 16?",
+                  "required": "FALSE",
+                  "hint": "",
+                  "inputs": [
+                    {
+                      "inputCriteria": {
+                        "id": "applicant_care_for_child",
+                        "type": "Radio",
+                        "name": "applicant_care_for_child",
+                        "label": "Are you caring for a child of someone who is retired, has a disability, or has died, and the child is disabled or under the age of 16?",
+                        "hasChild": "FALSE",
+                        "childDependencyOption": "",
+                        "values": [
+                          {
+                            "option": "Yes",
+                            "value": "Yes"
+                          },
+                          {
+                            "option": "No",
+                            "value": "No"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "children": []
+                }
+              },
+              {
+                "fieldset": {
+                  "criteriaKey": "applicant_paid_funeral_expenses",
+                  "legend": "Did you pay for funeral or burial expenses?",
+                  "required": "FALSE",
+                  "hint": "",
+                  "inputs": [
+                    {
+                      "inputCriteria": {
+                        "id": "applicant_paid_funeral_expenses",
+                        "type": "Radio",
+                        "name": "applicant_paid_funeral_expenses",
+                        "label": "Did you pay for funeral or burial expenses?",
+                        "hasChild": "FALSE",
+                        "childDependencyOption": "",
+                        "values": [
+                          {
+                            "option": "Yes",
+                            "value": "Yes"
+                          },
+                          {
+                            "option": "No",
+                            "value": "No"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "children": []
+                }
+              },
+              {
+                "fieldset": {
+                  "criteriaKey": "applicant_funeral_reimbursement",
+                  "legend": "Did you pay for funeral or burial expenses?",
+                  "required": "FALSE",
+                  "hint": "",
+                  "inputs": [
+                    {
+                      "inputCriteria": {
+                        "id": "applicant_funeral_reimbursement",
+                        "type": "Radio",
+                        "name": "applicant_funeral_reimbursment",
+                        "label": "Did any organization or government agency reimburse you for any funeral or burial expenses?",
+                        "hasChild": "FALSE",
+                        "childDependencyOption": "",
+                        "values": [
+                          {
+                            "option": "Yes",
+                            "value": "Yes"
+                          },
+                          {
+                            "option": "No",
+                            "value": "No"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "children": []
                 }
               }
             ]
@@ -411,7 +403,7 @@
               {
                 "fieldset": {
                   "criteriaKey": "deceased_miner",
-                  "legend": "",
+                  "legend": "Did the person work in the coal mines and their death was due to black lung disease (pneumoconiosis)?",
                   "required": "FALSE",
                   "hint": "",
                   "inputs": [
@@ -514,8 +506,8 @@
                         "type": "Radio",
                         "name": "deceased_served_in_active_military",
                         "label": "Did the deceased serve in active military service?",
-                        "hasChild": "FALSE",
-                        "childDependencyOption": "",
+                        "hasChild": "TRUE",
+                        "childDependencyOption": "Yes",
                         "values": [
                           {
                             "option": "Yes",
@@ -535,7 +527,7 @@
                         {
                           "fieldset": {
                             "criteriaKey": "deceased_service_status",
-                            "legend": "",
+                            "legend": "What was the service status of the deceased?",
                             "required": "FALSE",
                             "hint": "",
                             "inputs": [
@@ -568,91 +560,89 @@
                                 }
                               }
                             ],
-                            "children": [
+                            "children": []
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "fieldsets": [
+                        {
+                          "fieldset": {
+                            "criteriaKey": "deceased_military_death_circumstance",
+                            "legend": "Which option applies to the deceased?",
+                            "required": "FALSE",
+                            "hint": "",
+                            "inputs": [
                               {
-                                "fieldsets": [
-                                  {
-                                    "fieldset": {
-                                      "criteriaKey": "deceased_military_death_circumstance",
-                                      "legend": "",
-                                      "required": "FALSE",
-                                      "hint": "",
-                                      "inputs": [
-                                        {
-                                          "inputCriteria": {
-                                            "id": "deceased_military_death_circumstance",
-                                            "type": "Radio",
-                                            "name": "deceased_military_death_circumstance",
-                                            "label": "Which option applies to the deceased?",
-                                            "hasChild": "FALSE",
-                                            "childDependencyOption": "",
-                                            "values": [
-                                              {
-                                                "option": "Died while on active duty",
-                                                "value": "Died while on active duty"
-                                              },
-                                              {
-                                                "option": "Died while on inactive-duty training",
-                                                "value": "Died while on inactive-duty training"
-                                              },
-                                              {
-                                                "option": "Died as a result of a service-related disability/illness",
-                                                "value": "Died as a result of a service-related disability/illness"
-                                              },
-                                              {
-                                                "option": "Died while receiving/traveling to VA care",
-                                                "value": "Died while receiving/traveling to VA care"
-                                              },
-                                              {
-                                                "option": "Died while receiving/eligible for VA compensation",
-                                                "value": "Died while receiving/eligible for VA compensation"
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      ],
-                                      "children": [
-                                        {
-                                          "fieldsets": [
-                                            {
-                                              "fieldset": {
-                                                "criteriaKey": "deceased_grave_headstone",
-                                                "legend": "",
-                                                "required": "FALSE",
-                                                "hint": "",
-                                                "inputs": [
-                                                  {
-                                                    "inputCriteria": {
-                                                      "id": "deceased_grave_headstone",
-                                                      "type": "Radio",
-                                                      "name": "deceased_grave_headstone",
-                                                      "label": "Is the person buried in a grave with a privately purchased headstone or in an unmarked grave?",
-                                                      "hasChild": "FALSE",
-                                                      "childDependencyOption": "",
-                                                      "values": [
-                                                        {
-                                                          "option": "Yes",
-                                                          "value": "Yes"
-                                                        },
-                                                        {
-                                                          "option": "No",
-                                                          "value": "No"
-                                                        }
-                                                      ]
-                                                    }
-                                                  }
-                                                ],
-                                                "children": []
-                                              }
-                                            }
-                                          ]
-                                        }
-                                      ]
+                                "inputCriteria": {
+                                  "id": "deceased_military_death_circumstance",
+                                  "type": "Radio",
+                                  "name": "deceased_military_death_circumstance",
+                                  "label": "Which option applies to the deceased?",
+                                  "hasChild": "FALSE",
+                                  "childDependencyOption": "",
+                                  "values": [
+                                    {
+                                      "option": "Died while on active duty",
+                                      "value": "Died while on active duty"
+                                    },
+                                    {
+                                      "option": "Died while on inactive-duty training",
+                                      "value": "Died while on inactive-duty training"
+                                    },
+                                    {
+                                      "option": "Died as a result of a service-related disability/illness",
+                                      "value": "Died as a result of a service-related disability/illness"
+                                    },
+                                    {
+                                      "option": "Died while receiving/traveling to VA care",
+                                      "value": "Died while receiving/traveling to VA care"
+                                    },
+                                    {
+                                      "option": "Died while receiving/eligible for VA compensation",
+                                      "value": "Died while receiving/eligible for VA compensation"
                                     }
-                                  }
-                                ]
+                                  ]
+                                }
                               }
-                            ]
+                            ],
+                            "children": []
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "fieldsets": [
+                        {
+                          "fieldset": {
+                            "criteriaKey": "deceased_grave_headstone",
+                            "legend": "Is the person buried in a grave with a privately purchased headstone or an unmarked grave?",
+                            "required": "FALSE",
+                            "hint": "",
+                            "inputs": [
+                              {
+                                "inputCriteria": {
+                                  "id": "deceased_grave_headstone",
+                                  "type": "Radio",
+                                  "name": "deceased_grave_headstone",
+                                  "label": "Is the person buried in a grave with a privately purchased headstone or in an unmarked grave?",
+                                  "hasChild": "FALSE",
+                                  "childDependencyOption": "",
+                                  "values": [
+                                    {
+                                      "option": "Yes",
+                                      "value": "Yes"
+                                    },
+                                    {
+                                      "option": "No",
+                                      "value": "No"
+                                    }
+                                  ]
+                                }
+                              }
+                            ],
+                            "children": []
                           }
                         }
                       ]
@@ -668,8 +658,304 @@
     "benefits": [
       {
         "benefit": {
+          "title": "Burial benefits",
+          "summary": "<p>Burial and transport assistance for the deceased, and travel support for the spouse, children, and immediate family members of the service member.</p>",
+          "SourceLink": "https://www.dcms.uscg.mil/Portals/10/CG-1/PSC/PSD/docs/SurvivorsGuide2015.pdf?ver=2017-03-24-132033-397",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Department of Defense (DOD)",
+            "summary": "<p>Provides support for qualified spouses, children, and other family members of deceased service members.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty member",
+              "acceptableValues": [
+                "Active-duty member"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died on active duty",
+              "acceptableValues": [
+                "Died on active duty"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Applicant's relationship to the deceased is: spouse, child, parent, or other family member",
+              "acceptableValues": [
+                "Spouse",
+                "Child",
+                "Parent",
+                "Other family member"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Death gratuity",
+          "summary": "<p>Tax free payment of $100,000 to eligible survivors of members of the Armed Forces who died while on active duty or while serving in certain reserve statuses.</p>",
+          "SourceLink": "https://militarypay.defense.gov/Benefits/Death-Gratuity/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Department of Defense (DOD)",
+            "summary": "<p>Provides support for qualified spouses, children, and other family members of deceased service members.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member or member of the National Guard/Reserves",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Member of the National Guard/Reserves"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died while on active duty or Died while on inactive-duty service training",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died while on inactive-duty service training"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
+              "acceptableValues": [
+                "Spouse",
+                "Child",
+                "Parent",
+                "Other family member"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Burial flag",
+          "summary": "<p>A United States flag for the coffin or urn in honor of the military service member.</p>",
+          "SourceLink": "https://www.va.gov/burials-memorials/memorial-items/burial-flags/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "The deceased served in the active military"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, or member of the National Guard/Reserves ",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable",
+                "Member of the National Guard/Reserves"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
+              "acceptableValues": [
+                "Spouse",
+                "Child",
+                "Parent",
+                "Other family member"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Annuity for Certain Military Surviving Spouses",
+          "summary": "<p>Financial support for surviving spouses of members of the uniformed services.</p>",
+          "SourceLink": "https://militarypay.defense.gov/Benefits/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Department of Defense (DOD)",
+            "summary": "<p>Provides support for qualified spouses, children, and other family members of deceased service members.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_date_of_death",
+              "label": "Deceased died before 1978",
+              "acceptableValues": [
+                "<01-01-1978"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "You served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: retired from the service",
+              "acceptableValues": [
+                "Retired from the service"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse",
+              "acceptableValues": [
+                "Spouse"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Burial in VA national cemetery",
+          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->Veterans, service members, and some family members may be eligible for burial in VA national cemeteries.</p>",
+          "SourceLink": "https://www.va.gov/burials-memorials/eligibility/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, or member of the National Guard/Reserves",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable",
+                "Member of the National Guard/Reserves"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, died while receiving/traveling to VA care, or died while receiving/eligible for VA compensation",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died as a result of a service-related disability/illness",
+                "Died while receiving/traveling to VA care",
+                "Died while receiving/eligible for VA compensation"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Civilian Health and Medical Program of the VA (CHAMPVA) for child",
+          "summary": "<p>Health insurance for dependents and surviving spouses covering some health care services and supplies.</p>",
+          "SourceLink": "https://www.va.gov/health-care/family-caregiver-benefits/champva/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member or discharged under conditions other than dishonorable",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died while on active duty or died as a result of a service-related disability/illness",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died as a result of a service-related disability/illness"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_date_of_birth",
+              "label": "You are under 18 years",
+              "acceptableValues": [
+                "<18years"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is: unmarried ",
+              "acceptableValues": [
+                "Unmarried"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: child",
+              "acceptableValues": [
+                "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
           "title": "COVID-19 funeral assistance",
-          "summary": "<p>Financial assistance to coversome burial and funeral costs for people who died of COVID-19.</p>",
+          "summary": "<p>Financial assistance for burial and funeral costs for someone who died of COVID-19. To be eligible, you were not reimbursed from an organization or agency.</p>",
           "SourceLink": "https://www.fema.gov/disasters/coronavirus/economic/funeral-assistance",
           "SourceIsEnglish": "FALSE",
           "agency": {
@@ -711,9 +997,375 @@
             },
             {
               "criteriaKey": "applicant_paid_funeral_expenses",
-              "label": "You paid for funeral/burial expenses and were not reimbursed by any organization or agency",
+              "label": "You paid for funeral or burial expenses and were not reimbursed",
               "acceptableValues": [
                 "Yes"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Dependency and Indemnity Compensation (DIC) for child",
+          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->Tax-free financial assistance to surviving children or family members of service members and veterans.</p>",
+          "SourceLink": "https://www.va.gov/disability/dependency-indemnity-compensation/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "Did the deceased serve in the active military, naval, or air service?",
+              "acceptableValues": [
+                "You served in the active military"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member or discharged under conditions other than dishonorable",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, or died while receiving/eligible for VA compensation",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died as a result of a service-related disability/illness",
+                "Died while receiving/eligible for VA compensation"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_date_of_birth",
+              "label": "You are under 18 years",
+              "acceptableValues": [
+                "<18years"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is: unmarried",
+              "acceptableValues": [
+                "Unmarried"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: child",
+              "acceptableValues": [
+                "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Dependency and Indemnity Compensation (DIC) for parent",
+          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->Tax-free financial assistance to surviving parents or family members of service members and veterans.</p>",
+          "SourceLink": "https://www.va.gov/disability/dependency-indemnity-compensation/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member or discharged under conditions other than dishonorable",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, or died while receiving/eligible for VA compensation",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died as a result of a service-related disability/illness",
+                "Died while receiving/eligible for VA compensation"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_income",
+              "label": "You have limited income and resources",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: parent",
+              "acceptableValues": [
+                "Parent"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Dependency and Indemnity Compensation (DIC) for spouse",
+          "summary": "<p>Tax-free financial assistance to surviving spouses or family members of service members or veterans.</p>",
+          "SourceLink": "https://www.va.gov/disability/dependency-indemnity-compensation/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "Did the deceased serve in the active military, naval, or air service?",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "What was the service status of the deceased?",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "Which option applies to the deceased?",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died as a result of a service-related disability/illness",
+                "Died while receiving/eligible for VA compensation"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Marital status",
+              "acceptableValues": [
+                "Unmarried",
+                "Widowed"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Applicant's relationship to the deceased:",
+              "acceptableValues": [
+                "Spouse"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Education benefits (GI Bill) for survivors",
+          "summary": "<p>VA education benefits or job training for dependents and survivors of a veteran.</p>",
+          "SourceLink": "https://www.va.gov/education/survivor-dependent-benefits/",
+          "SourceIsEnglish": "FALSE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: Active-duty service member or discharged under conditions other than dishonorable",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died while on active duty or died as a result of a service-related disability/illness",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died as a result of a service-related disability/illness"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_high-school_diploma",
+              "label": "You have a high school diploma or GED certificate",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse or child",
+              "acceptableValues": [
+                "Spouse",
+                "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Financial Assistance and Social Services (FASS)",
+          "summary": "<p>Assistance with burial expenses of deceased indigent Indians who do not have resources for funeral expenses.</p>",
+          "SourceLink": "https://www.bia.gov/bia/ois/dhs/financial-assistance",
+          "SourceIsEnglish": "FALSE",
+          "agency": {
+            "title": "Department of Interior (DOI) - Indian Affairs",
+            "summary": "<p>The Bureau of Indian Affairs enhances the quality of life and protects and improves the trust assets of American Indians, Indian tribes, and Alaska Natives.</p>",
+            "lede": "<p>The Bureau of Indian Affairs enhances the quality of life and protects and improves the trust assets of American Indians, Indian tribes, and Alaska Natives.</p>"
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_american_indian",
+              "label": "The deceased was a member of a federally recognized American Indian Tribe or an Alaska Native.",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_income",
+              "label": "You have limited income and resources",
+              "acceptableValues": [
+                "Yes"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Home loan program for survivors",
+          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->VA-backed home loan to surviving spouses of veterans.</p>",
+          "SourceLink": "https://www.va.gov/housing-assistance/home-loans/surviving-spouse/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is:",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, Died while receiving/traveling to VA care, or died while receiving/eligible for VA compensation",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died as a result of a service-related disability/illness",
+                "Died while receiving/traveling to VA care",
+                "Died while receiving/eligible for VA compensation"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is widowed",
+              "acceptableValues": [
+                "Widowed"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse",
+              "acceptableValues": [
+                "Spouse"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Life insurance for survivors of veterans",
+          "summary": "<p>Payment from a veteran's or service member's life insurance policy.</p>",
+          "SourceLink": "https://www.benefits.va.gov/INSURANCE/sglivgli.asp",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, retired from the service, or member of the National Guard/Reserves",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable",
+                "Retired from the service",
+                "Member of the National Guard/Reserves"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
+              "acceptableValues": [
+                "Spouse",
+                "Child",
+                "Parent",
+                "Other family member"
               ]
             }
           ]
@@ -761,6 +1413,887 @@
               "acceptableValues": [
                 "Spouse",
                 "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Presidential Memorial Certificate",
+          "summary": "<p>An engraved Presidential Memorial Certificate (PMC) signed by the current president honoring the military service of a veteran or reservist.</p>",
+          "SourceLink": "https://www.va.gov/burials-memorials/memorial-items/presidential-memorial-certificates/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, or member of the National Guard/Reserves",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable",
+                "Member of the National Guard/Reserves"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died while on active duty, died as a result of a service-related disability/illness, died while receiving/traveling to VA care, or died while receiving/eligible for VA compensation",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died as a result of a service-related disability/illness",
+                "Died while receiving/traveling to VA care",
+                "Died while receiving/eligible for VA compensation"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
+              "acceptableValues": [
+                "Spouse",
+                "Child",
+                "Parent",
+                "Other family member"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Public Safety Officers' Death Benefits",
+          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->A one-time benefit for survivors of law enforcement officers, firefighters, and other first responders whose deaths were the result of an injury sustained in the line of duty.</p>",
+          "SourceLink": "https://psob.bja.ojp.gov/PSOB_FactSheet2019.pdf",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Department of Justice (DOJ)",
+            "summary": "<p>Offers financial and educational support to help families of fallen public safety officers.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_public_safety_officer",
+              "label": "The deceased was a public safety officer who died in the line of duty",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
+              "acceptableValues": [
+                "Spouse",
+                "Child",
+                "Parent",
+                "Other family member"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Public Safety Officers' Educational Assistance Program",
+          "summary": "<p>Financial assistance for higher education to spouses and children of police, fire, and emergency public safety officers killed in the line of duty.</p>",
+          "SourceLink": "https://psob.bja.ojp.gov/PSOB_Education2018.pdf",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Department of Justice (DOJ)",
+            "summary": "<p>Offers financial and educational support to help families of fallen public safety officers.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_public_safety_officer",
+              "label": "The deceased was a public safety officer who died in the line of duty",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse or child",
+              "acceptableValues": [
+                "Spouse",
+                "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivor benefit plan",
+          "summary": "<p>Up to 55% of a service member's retired pay for survivors of active duty service members and some retired and reserve members.</p>",
+          "SourceLink": "https://militarypay.defense.gov/Benefits/Survivor-Benefit-Program/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Department of Defense (DOD)",
+            "summary": "<p>Provides support for qualified spouses, children, and other family members of deceased service members.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member, retired from the service, or member of the National Guard/Reserves",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Retired from the service",
+                "Member of the National Guard/Reserves"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died while on active duty or died while on inactive-duty service training",
+              "acceptableValues": [
+                "Died while on active duty",
+                "Died while on inactive-duty service training"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse or child",
+              "acceptableValues": [
+                "Spouse",
+                "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivors benefits for child",
+          "summary": "<p>Social Security survivors benefits paid to a child, stepchild, grandchild, or adopted child of eligible workers.</p>",
+          "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h4",
+          "SourceIsEnglish": "FALSE",
+          "agency": {
+            "title": "Social Security Administration (SSA)",
+            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_paid_into_SS",
+              "label": "The deceased worked and paid Social Security taxes",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_date_of_birth",
+              "label": "You are under 18 years",
+              "acceptableValues": [
+                "<18years"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is unmarried",
+              "acceptableValues": [
+                "Unmarried"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_citizen_status",
+              "label": "You are a U.S. citizen or eligible non-citizen",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Applicant's relationship to the deceased is: child",
+              "acceptableValues": [
+                "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivors benefits for child with disabilities",
+          "summary": "<p>Social Security survivors benefits to a child, stepchild, grandchild, or adopted child with disabilities of eligible workers.</p>",
+          "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h4",
+          "SourceIsEnglish": "FALSE",
+          "agency": {
+            "title": "Social Security Administration (SSA)",
+            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_paid_into_SS",
+              "label": "The deceased worked and paid Social Security taxes",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_date_of_birth",
+              "label": "You are under 18 years",
+              "acceptableValues": [
+                "<18years"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is unmarried",
+              "acceptableValues": [
+                "Unmarried"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_citizen_status",
+              "label": "You are a U.S. citizen or eligible non-citizen",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_disability",
+              "label": "You have a disability",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_ability_to_work",
+              "label": "You are unable to work for a year or more because of a disability or your disability is expected to result in death",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: child",
+              "acceptableValues": [
+                "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivors benefits for mothers/fathers",
+          "summary": "<p>Social Security survivors benefits to the person providing care for the child of a deceased worker.</p>",
+          "SourceLink": "https://www.ssa.gov/forms/ssa-5.html",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Social Security Administration (SSA)",
+            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_paid_into_SS",
+              "label": "The deceased worked and paid Social Security taxes",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is unmarried or widowed",
+              "acceptableValues": [
+                "Unmarried",
+                "Widowed"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_citizen_status",
+              "label": "You are a US citizen or eligible non-citizen",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_care_for_child",
+              "label": "You are caring for a child of someone who is retired, has a disability, or has died, and the child is disabled or under the age of 16",
+              "acceptableValues": [
+                "Yes"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivors benefits for parents",
+          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->Social Security survivors benefits to parents of eligible workers.</p>",
+          "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h5",
+          "SourceIsEnglish": "FALSE",
+          "agency": {
+            "title": "Social Security Administration (SSA)",
+            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_paid_into_SS",
+              "label": "The deceased worked and paid Social Security taxes",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_date_of_birth",
+              "label": "You are over 62 years",
+              "acceptableValues": [
+                ">=62years"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_citizen_status",
+              "label": "You are a US citizen or eligible non-citizen",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: parent",
+              "acceptableValues": [
+                "Parent"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivors benefits for spouse",
+          "summary": "<p>Social Security survivors benefits to surviving spouses and certain divorced spouses of eligible workers.</p>",
+          "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h2",
+          "SourceIsEnglish": "FALSE",
+          "agency": {
+            "title": "Social Security Administration (SSA)",
+            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_paid_into_SS",
+              "label": "The deceased worked and paid Social Security taxes",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_date_of_birth",
+              "label": "You are over 60 years",
+              "acceptableValues": [
+                ">=60years"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is widowed or divorced",
+              "acceptableValues": [
+                "Widowed",
+                "Divorced"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_citizen_status",
+              "label": "You are a US citizen or eligible non-citizen",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse",
+              "acceptableValues": [
+                "Spouse"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivors benefits for spouse with disabilities",
+          "summary": "<p>Social Security survivors benefits to surviving spouses and certain divorced spouses with disabilities of eligible workers.</p>",
+          "SourceLink": "https://www.ssa.gov/benefits/survivors/ifyou.html#h2",
+          "SourceIsEnglish": "FALSE",
+          "agency": {
+            "title": "Social Security Administration (SSA)",
+            "summary": "<p>Administers Social Security, as well as disability insurance, and other benefits.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_paid_into_SS",
+              "label": "Did the deceased ever work and pay Social Security taxes on their earnings?",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_date_of_birth",
+              "label": "You are over 50 years",
+              "acceptableValues": [
+                ">=50years"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is widowed or divorced",
+              "acceptableValues": [
+                "Widowed",
+                "Divorced"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_citizen_status",
+              "label": "You are a US citizen or eligible non-citizen",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_disability",
+              "label": "You have a disability",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_ability_to_work",
+              "label": "You are unable to work for a year or more because of a disability or your disability is expected to result in death",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse",
+              "acceptableValues": [
+                "Spouse"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivors pension for child",
+          "summary": "<p>Monthly payments to qualified unmarried dependent children of deceased wartime veterans.</p>",
+          "SourceLink": "https://www.va.gov/pension/survivors-pension/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "You served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "Your service status is: discharged for conditions other than dishonorable",
+              "acceptableValues": [
+                "Discharged for conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_date_of_birth",
+              "label": "You are under 18 years",
+              "acceptableValues": [
+                "<18years"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is unmarried",
+              "acceptableValues": [
+                "Unmarried"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: child",
+              "acceptableValues": [
+                "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivors pension for child with disabilities",
+          "summary": "<p>Monthly payments to qualified unmarried dependent children with disabilities of wartime veterans with certain income and net worth limits.</p>",
+          "SourceLink": "https://www.va.gov/pension/survivors-pension/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: discharged for conditions other than dishonorable",
+              "acceptableValues": [
+                "Discharged for conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_date_of_birth",
+              "label": "You are under 18 years",
+              "acceptableValues": [
+                ">18years"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is unmarried",
+              "acceptableValues": [
+                "Unmarried"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_disability",
+              "label": "You have a disability",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: child",
+              "acceptableValues": [
+                "Child"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Survivors pension for spouse",
+          "summary": "<p>Monthly payments to surviving spouses of wartime veterans with certain income and net worth limits.</p>",
+          "SourceLink": "https://www.va.gov/pension/survivors-pension/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: discharged for conditions other than dishonorable",
+              "acceptableValues": [
+                "Discharged for conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_marital_status",
+              "label": "Your marital status is unmarried or widowed",
+              "acceptableValues": [
+                "Unmarried",
+                "Widowed"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_income",
+              "label": "You have limited income and resources",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse",
+              "acceptableValues": [
+                "Spouse"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Veterans burial allowance",
+          "summary": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->Assistance with burial, funeral, and transportation costs of a deceased veteran.</p>",
+          "SourceLink": "https://www.va.gov/burials-memorials/veterans-burial-allowance/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_date_of_death",
+              "label": "The deceased died within the last two years",
+              "acceptableValues": [
+                "<2years (The deceased died within the last two years.)"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: discharged for conditions other than dishonorable",
+              "acceptableValues": [
+                "Discharged for conditions other than dishonorable"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_military_death_circumstance",
+              "label": "One of the following applies to the deceased: died as a result of a service-related disability/illness, died while receiving/traveling to VA care, or died while receiving/eligible for VA compensation",
+              "acceptableValues": [
+                "Died as a result of a service-related disability/illness",
+                "Died while receiving/traveling to VA care",
+                "Died while receiving/eligible for VA compensation"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
+              "acceptableValues": [
+                "Spouse",
+                "Child",
+                "Parent",
+                "Other family member"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_paid_funeral_expenses",
+              "label": "You paid for funeral or burial expenses",
+              "acceptableValues": [
+                "Yes"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Veterans headstone and grave marker",
+          "summary": "<p>A headstone, grave or niche marker, or medallion to honor a veteran, service member, or eligible family member.</p>",
+          "SourceLink": "https://www.va.gov/burials-memorials/memorial-items/headstones-markers-medallions/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, or member of the National Guard/Reserves",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable",
+                "Member of the National Guard/Reserves"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_grave_headstone",
+              "label": "The person is buried in a grave with a privately purchased headstone or an unmarked grave",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
+              "acceptableValues": [
+                "Spouse",
+                "Child",
+                "Parent",
+                "Other family member"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Veterans medallion",
+          "summary": "<p>A headstone medallion, grave marker, and Presidential Memorial Certificate for eligible veterans buried in a private cemetery.</p>",
+          "SourceLink": "https://www.va.gov/burials-memorials/memorial-items/headstones-markers-medallions/",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Veterans Affairs Department (VA)",
+            "summary": "<p>Provides a wide range of benefits in support of veterans, service members, and their families.</p>",
+            "lede": ""
+          },
+          "tags": [
+            "Death of a loved one"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "deceased_served_in_active_military",
+              "label": "The deceased served in the active military",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_service_status",
+              "label": "The service status of the deceased is: active-duty service member, discharged under conditions other than dishonorable, or a member of the National Guard/Reserves",
+              "acceptableValues": [
+                "Active-duty service member",
+                "Discharged under conditions other than dishonorable",
+                "Member of the National Guard/Reserves"
+              ]
+            },
+            {
+              "criteriaKey": "deceased_grave_headstone",
+              "label": "The person is buried in a grave with a privately purchased headstone or an unmarked grave",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_relationship_to_the_deceased",
+              "label": "Your relationship to the deceased is: spouse, child, parent, or other family member",
+              "acceptableValues": [
+                "Spouse",
+                "Child",
+                "Parent",
+                "Other family member"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "benefit": {
+          "title": "Coal Mine Workers' Compensation (black lung benefits)",
+          "summary": "<p>Compensation to coal miners who were totally disabled by black lung disease (pneumoconiosis) or surviving spouses of miners whose deaths are attributable to this disease.&nbsp;</p><p>Also provides medical coverage for treatment of related lung diseases.</p>",
+          "SourceLink": "https://www.dol.gov/agencies/owcp/dcmwc/filing_guide_miner",
+          "SourceIsEnglish": "TRUE",
+          "agency": {
+            "title": "Department of Labor (DOL)",
+            "summary": "<p>Promotes and improves the welfare, working conditions, opportunities, benefits and rights of wage earners, job seekers, and retirees of the United States.</p>",
+            "lede": "<p><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->Promotes and improves the welfare, working conditions, opportunities, benefits and rights of wage earners, job seekers, and retirees of the United States.</p>"
+          },
+          "tags": [
+            "Disability benefits",
+            "Retirement"
+          ],
+          "eligibility": [
+            {
+              "criteriaKey": "applicant_disability",
+              "label": "Do you have a physical or mental impairment (including an emotional or learning disability)?",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_ability_to_work",
+              "label": "You are unable to work for a year or more because of a disability or your disability is expected to result in death",
+              "acceptableValues": [
+                "Yes"
+              ]
+            },
+            {
+              "criteriaKey": "applicant_miner",
+              "label": "You worked in the coal mining industry and suffer from an illness caused by black lung disease (pneumoconiosis)",
+              "acceptableValues": [
+                "Yes"
               ]
             }
           ]

--- a/bears-app/src/shared/components/BenefitAccordionGroup/index.jsx
+++ b/bears-app/src/shared/components/BenefitAccordionGroup/index.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import PropTypes from 'prop-types'
+import createMarkup from '../../utils/createMarkup'
 import {
   Accordion,
   Alert,
@@ -7,7 +8,6 @@ import {
   Heading,
   KeyElegibilityCrieriaList,
   ObfuscatedLink,
-  Paragraph,
 } from '../index'
 import './_index.scss'
 
@@ -154,9 +154,10 @@ const BenefitAccordionGroup = ({ data, entryKey, expandAll }) => {
               <Heading className="benefit-detail-title" headingLevel={4}>
                 {`Provided by ${agency.title}`}
               </Heading>
-              <Paragraph className="benefit-detail-summary">
-                {summary}
-              </Paragraph>
+              <div
+                className="benefit-detail-summary"
+                dangerouslySetInnerHTML={createMarkup(summary)}
+              />
               <KeyElegibilityCrieriaList
                 className="benefit-criteria-list"
                 data={eligibleBenefits}

--- a/bears-app/src/shared/components/BenefitAccordionGroup/index.jsx
+++ b/bears-app/src/shared/components/BenefitAccordionGroup/index.jsx
@@ -115,12 +115,12 @@ const BenefitAccordionGroup = ({ data, entryKey, expandAll }) => {
           )
           // filter to get unmet criteria
           const notEligibleBenefits = eligibility.filter(
-            item => item.isEligible === false || item.isEligible === undefined
+            item => item.isEligible === false
           )
 
           // filter to get criteria without user values to compare with
           const moreInformationNeeded = eligibility.filter(
-            item => item.isEligible === 'undefined'
+            item => item.isEligible === undefined
           )
           // determine the eligibility statues based on the benefits length
           // Total Criteria = y

--- a/bears-app/src/shared/components/BenefitAccordionGroup/index.jsx
+++ b/bears-app/src/shared/components/BenefitAccordionGroup/index.jsx
@@ -179,6 +179,9 @@ const BenefitAccordionGroup = ({
                 notQualifiedView === false &&
                 eligibleStatus !== 'Likely Eligible'
                   ? { display: 'none' }
+                  : notQualifiedView === true &&
+                    eligibleStatus === 'Likely Eligible'
+                  ? { display: 'none' }
                   : {}
               }
               key={`${index}-${title}`}

--- a/bears-app/src/shared/components/BenefitAccordionGroup/index.jsx
+++ b/bears-app/src/shared/components/BenefitAccordionGroup/index.jsx
@@ -140,7 +140,6 @@ const BenefitAccordionGroup = ({
       <ExpandAll />
       {data &&
         data.map((item, index) => {
-          console.log(item)
           const { agency, eligibility, sourceLink, summary, title } =
             item[entryKey]
           // filter to get benefit criteria matches

--- a/bears-app/src/shared/components/BenefitAccordionGroup/index.jsx
+++ b/bears-app/src/shared/components/BenefitAccordionGroup/index.jsx
@@ -19,13 +19,19 @@ import './_index.scss'
  * @param {bool} expandAll - determnines if we include ExpandAll component
  * @return {html} returns html
  */
-const BenefitAccordionGroup = ({ data, entryKey, expandAll }) => {
+const BenefitAccordionGroup = ({
+  data,
+  entryKey,
+  expandAll,
+  notQualifiedView,
+}) => {
   /**
    * a hook that hanldes our open state of the accordions in our group
    * @function
    * @return {boolean} returns true or false
    */
   const [isExpandAll, setExpandAll] = useState(false)
+  // const [filterData, setFilterData] = useState(null)
 
   /**
    * a function that returns the string value of our expanded action
@@ -102,11 +108,39 @@ const BenefitAccordionGroup = ({ data, entryKey, expandAll }) => {
     )
   }
 
+  // const qualifiedViewData = () => {
+  //   return data.filter(item =>
+  //     item.benefit.eligibility.find(e => e.isEligible && e.isEligible === true)
+  //   )
+  // }
+
+  // const notQualifiedViewData = () => {
+  //   return data.filter(item =>
+  //     item.benefit.eligibility.find(e => e.isEligible && e.isEligible !== true)
+  //   )
+  // }
+
+  // const notQualifiedViewData = () => {
+  //   return data.map(item => {
+  //     const { eligibility } = item[entryKey]
+  //     return eligibility.filter(
+  //       item => item.isEligible === false || item.isEligible === undefined
+  //     )
+  //   })
+  // }
+
+  // notQualifiedView === true
+  //   ? setFilterData(notQualifiedViewData)
+  //   : setFilterData(qualifiedViewData)
+
+  // console.log('qualified', qualifiedViewData)
+
   return (
     <div className="benefit-accordion-group">
       <ExpandAll />
       {data &&
         data.map((item, index) => {
+          console.log(item)
           const { agency, eligibility, sourceLink, summary, title } =
             item[entryKey]
           // filter to get benefit criteria matches
@@ -142,6 +176,12 @@ const BenefitAccordionGroup = ({ data, entryKey, expandAll }) => {
 
           return (
             <Accordion
+              style={
+                notQualifiedView === false &&
+                eligibleStatus !== 'Likely Eligible'
+                  ? { display: 'none' }
+                  : {}
+              }
               key={`${index}-${title}`}
               id={`${index}-${title}`}
               heading={title}

--- a/bears-app/src/shared/components/Fieldset/__tests__/__snapshots__/index.spec.js.snap
+++ b/bears-app/src/shared/components/Fieldset/__tests__/__snapshots__/index.spec.js.snap
@@ -2,6 +2,6 @@
 
 exports[`Fieldset renders a match to the previous snapshot 1`] = `
 <fieldset
-  className="usa-fieldset"
+  className="usa-fieldset "
 />
 `;

--- a/bears-app/src/shared/components/Fieldset/index.jsx
+++ b/bears-app/src/shared/components/Fieldset/index.jsx
@@ -10,7 +10,14 @@ import PropTypes from 'prop-types'
  * @return {html} returns a div
  */
 
-const Fieldset = ({ children, legend, required, alertRef, requiredLabel }) => {
+const Fieldset = ({
+  children,
+  legend,
+  required,
+  alertRef,
+  requiredLabel,
+  hidden,
+}) => {
   const RequiredFlag = () => (
     <>
       <Legend>
@@ -24,7 +31,12 @@ const Fieldset = ({ children, legend, required, alertRef, requiredLabel }) => {
     required === 'FALSE' ? <Legend>{legend}</Legend> : RequiredFlag()
 
   return (
-    <fieldset className="usa-fieldset" ref={alertRef}>
+    <fieldset
+      className={`usa-fieldset ${
+        hidden !== undefined && hidden ? 'display-none' : ''
+      }`}
+      ref={alertRef}
+    >
       {legend && handleRequired}
       {children}
     </fieldset>

--- a/bears-app/src/shared/components/LifeEventSection/index.jsx
+++ b/bears-app/src/shared/components/LifeEventSection/index.jsx
@@ -106,10 +106,8 @@ const LifeEventSection = ({
   const handleCheckRequriedFields = () => {
     // collect all the required fields in the current step
     getRequiredFields()
-    // console.log(values)
     // check if any of these elements are valid (will add others later)
     const valid = element => {
-      console.log(element)
       return !element.classList.contains('required-field')
     }
 
@@ -275,10 +273,8 @@ const LifeEventSection = ({
                 )}
               ></div>
 
-              {/* TODO: create handler component for input case switching */}
-
               {currentData.section.fieldsets.map((item, i) => {
-                const Input = ({ item, children, index }) =>
+                const Input = ({ item, children, index, hidden }) =>
                   item.fieldset.inputs[0].inputCriteria.type === 'Select' ? (
                     //
                     //
@@ -292,6 +288,7 @@ const LifeEventSection = ({
                         hint={item.fieldset.hint}
                         required={item.fieldset.required}
                         requiredLabel={requiredLabel}
+                        hidden={hidden && hidden}
                       >
                         {item.fieldset.inputs.map((input, index) => {
                           const fieldSetId = `${item.fieldset.criteriaKey}_${index}`
@@ -338,6 +335,7 @@ const LifeEventSection = ({
                         hint={item.fieldset.hint}
                         required={item.fieldset.required}
                         requiredLabel={requiredLabel}
+                        hidden={hidden && hidden}
                       >
                         {item.fieldset.inputs.map((input, index) => {
                           const fieldSetId = `${item.fieldset.criteriaKey}_${index}`
@@ -394,6 +392,7 @@ const LifeEventSection = ({
                         hint={item.fieldset.hint}
                         required={item.fieldset.required}
                         requiredLabel={requiredLabel}
+                        hidden={hidden && hidden}
                       >
                         {item.fieldset.inputs.map((input, index) => {
                           const fieldSetId = `${item.fieldset.criteriaKey}_${index}`
@@ -426,8 +425,21 @@ const LifeEventSection = ({
 
                 const parentElement = ({ item, i }) => Input({ item, index: i })
 
-                const parentWithChildElement = ({ item, i }) =>
-                  item.fieldset.children.map((child, i) => {
+                const checkParentValue = item => {
+                  const selectedParentValue =
+                    item.fieldset.inputs[0].inputCriteria.values.find(
+                      value => value.selected === true
+                    )
+
+                  const hidden =
+                    selectedParentValue?.value !==
+                    item.fieldset.inputs[0].inputCriteria.childDependencyOption
+
+                  return hidden
+                }
+
+                const parentWithChildElement = ({ item, i }) => {
+                  return item.fieldset.children.map((child, i) => {
                     return (
                       child.fieldsets.length > 0 &&
                       child.fieldsets.map((childItem, childItemIndex) => {
@@ -437,11 +449,13 @@ const LifeEventSection = ({
                           children: Input({
                             item: childItem,
                             index: childItemIndex,
+                            hidden: checkParentValue(item),
                           }),
                         })
                       })
                     )
                   })
+                }
 
                 // children check
                 const fieldSet = () =>

--- a/bears-app/src/shared/components/LifeEventSection/index.jsx
+++ b/bears-app/src/shared/components/LifeEventSection/index.jsx
@@ -165,17 +165,17 @@ const LifeEventSection = ({
       element = arr.find(
         element => element.fieldset.criteriaKey === criteriaKey
       )
-      // handle children search
+
+      // handle children criteria
       if (element === undefined) {
         arr.forEach(item => {
-          item.fieldset.children &&
-            item.fieldset.children.forEach(
-              childElement =>
-                (element = childElement.fieldsets.find(
-                  childFieldset =>
-                    childFieldset.fieldset.criteriaKey === criteriaKey
-                ))
-            )
+          item.fieldset.children.forEach(childElement => {
+            if (
+              childElement.fieldsets[0].fieldset.criteriaKey === criteriaKey
+            ) {
+              element = childElement.fieldsets[0]
+            }
+          })
         })
       }
       return element
@@ -184,7 +184,8 @@ const LifeEventSection = ({
     const foundCriteria = findCriteria(newData.section.fieldsets, criteriaKey)
 
     // get those values
-    const inputValues = foundCriteria.fieldset.inputs[0].inputCriteria.values
+    const inputValues =
+      foundCriteria && foundCriteria.fieldset?.inputs[0].inputCriteria.values
 
     inputValues.forEach(value => {
       if (value.value === event.target.value) {
@@ -439,21 +440,20 @@ const LifeEventSection = ({
                 }
 
                 const parentWithChildElement = ({ item, i }) => {
-                  return item.fieldset.children.map((child, i) => {
-                    return (
-                      child.fieldsets.length > 0 &&
-                      child.fieldsets.map((childItem, childItemIndex) => {
-                        return Input({
-                          item,
-                          index: i,
-                          children: Input({
+                  return Input({
+                    item,
+                    index: i,
+                    children: item.fieldset.children.map(
+                      (child, i) =>
+                        child.fieldsets.length &&
+                        child.fieldsets.map((childItem, childItemIndex) =>
+                          Input({
                             item: childItem,
                             index: childItemIndex,
                             hidden: checkParentValue(item),
-                          }),
-                        })
-                      })
-                    )
+                          })
+                        )
+                    ),
                   })
                 }
 

--- a/bears-app/src/shared/components/LifeEventSection/index.jsx
+++ b/bears-app/src/shared/components/LifeEventSection/index.jsx
@@ -106,8 +106,10 @@ const LifeEventSection = ({
   const handleCheckRequriedFields = () => {
     // collect all the required fields in the current step
     getRequiredFields()
+    // console.log(values)
     // check if any of these elements are valid (will add others later)
     const valid = element => {
+      console.log(element)
       return !element.classList.contains('required-field')
     }
 
@@ -129,7 +131,6 @@ const LifeEventSection = ({
    * @return {null} only executes inherited functions
    */
   const handleUpdate = updateIndex => {
-    console.log(currentData)
     if (handleCheckRequriedFields() === true) {
       // set complete step usa-step-indicator__segment--complete
       setStep(step + updateIndex)
@@ -155,10 +156,35 @@ const LifeEventSection = ({
    */
   const handleChanged = (event, criteriaKey) => {
     const newData = { ...currentData }
+
     // find the right data based on criteriakey
-    const foundCriteria = newData.section.fieldsets.find(
-      element => element.fieldset.criteriaKey === criteriaKey
-    )
+    // check parent criteriaKey
+    // if nothing returns then check the children
+
+    const findCriteria = (arr, criteriaKey) => {
+      let element
+
+      element = arr.find(
+        element => element.fieldset.criteriaKey === criteriaKey
+      )
+      // handle children search
+      if (element === undefined) {
+        arr.forEach(item => {
+          item.fieldset.children &&
+            item.fieldset.children.forEach(
+              childElement =>
+                (element = childElement.fieldsets.find(
+                  childFieldset =>
+                    childFieldset.fieldset.criteriaKey === criteriaKey
+                ))
+            )
+        })
+      }
+      return element
+    }
+
+    const foundCriteria = findCriteria(newData.section.fieldsets, criteriaKey)
+
     // get those values
     const inputValues = foundCriteria.fieldset.inputs[0].inputCriteria.values
 
@@ -252,139 +278,178 @@ const LifeEventSection = ({
               {/* TODO: create handler component for input case switching */}
 
               {currentData.section.fieldsets.map((item, i) => {
-                // // TODO: exludes groups for now
-                // if (item.fieldset.fieldsets) {
-                //   return null
-                // }
-                return item.fieldset.inputs[0].inputCriteria.type ===
-                  'Select' ? (
-                  //
-                  //
-                  // case select
-                  //
-                  //
-                  <Fieldset
-                    key={`${item.fieldset.criteriaKey}-${i}`}
-                    legend={item.fieldset.legend}
-                    hint={item.fieldset.hint}
-                    required={item.fieldset.required}
-                    requiredLabel={requiredLabel}
-                  >
-                    {item.fieldset.inputs.map((input, index) => {
-                      const fieldSetId = `${item.fieldset.criteriaKey}_${index}`
-                      const inputValues = input.inputCriteria.values
-                      const defaultSelected = inputValues.find(
-                        value => value.selected !== undefined
-                      )
+                const Input = ({ item, children, index }) =>
+                  item.fieldset.inputs[0].inputCriteria.type === 'Select' ? (
+                    //
+                    //
+                    // case select
+                    //
+                    //
+                    <>
+                      <Fieldset
+                        key={`${item.fieldset.criteriaKey}-${index}`}
+                        legend={item.fieldset.legend}
+                        hint={item.fieldset.hint}
+                        required={item.fieldset.required}
+                        requiredLabel={requiredLabel}
+                      >
+                        {item.fieldset.inputs.map((input, index) => {
+                          const fieldSetId = `${item.fieldset.criteriaKey}_${index}`
+                          const inputValues = input.inputCriteria.values
+                          const defaultSelected = inputValues.find(
+                            value => value.selected !== undefined
+                          )
 
-                      return (
-                        <div key={fieldSetId}>
-                          <Select
-                            required={
-                              defaultSelected === undefined &&
-                              item.fieldset.required
-                            }
-                            ui={ui?.select}
-                            htmlFor={fieldSetId}
-                            key={fieldSetId}
-                            options={inputValues}
-                            selected={defaultSelected?.value}
-                            onChange={event =>
-                              handleChanged(event, item.fieldset.criteriaKey)
-                            }
-                          />
-                        </div>
-                      )
-                    })}
-                  </Fieldset>
-                ) : item.fieldset.inputs[0].inputCriteria.type === 'Radio' ? (
-                  //
-                  //
-                  // case radio
-                  //
-                  //
-                  <Fieldset
-                    key={`${item.fieldset.criteriaKey}-${i}`}
-                    legend={item.fieldset.legend}
-                    hint={item.fieldset.hint}
-                    required={item.fieldset.required}
-                    requiredLabel={requiredLabel}
-                  >
-                    {item.fieldset.inputs.map((input, index) => {
-                      const fieldSetId = `${item.fieldset.criteriaKey}_${index}`
-
-                      const inputValues = input.inputCriteria.values
-                      const optionSelected = inputValues.find(
-                        value => value.selected !== undefined
-                      )
-
-                      return (
-                        <div key={fieldSetId}>
-                          {/* map the options */}
-                          {input.inputCriteria.values.map((option, index) => {
-                            const inputId = `${fieldSetId}_${index}`
-
-                            return (
-                              <Radio
+                          return (
+                            <div key={fieldSetId}>
+                              <Select
                                 required={
-                                  !optionSelected && item.fieldset.required
+                                  defaultSelected === undefined &&
+                                  item.fieldset.required
                                 }
-                                id={inputId}
-                                key={inputId}
-                                label={option.value}
-                                value={option.value}
-                                checked={option.selected || false}
-                                onChange={event => {
+                                ui={ui?.select}
+                                htmlFor={fieldSetId}
+                                key={fieldSetId}
+                                options={inputValues}
+                                selected={defaultSelected?.value}
+                                onChange={event =>
                                   handleChanged(
                                     event,
                                     item.fieldset.criteriaKey
                                   )
-                                }}
+                                }
                               />
-                            )
-                          })}
-                        </div>
-                      )
-                    })}
-                  </Fieldset>
-                ) : item.fieldset.inputs[0].inputCriteria.type === 'Date' ? (
-                  //
-                  //
-                  // case date
-                  //
-                  //
-                  <Fieldset
-                    key={`${item.fieldset.criteriaKey}-${i}`}
-                    legend={item.fieldset.legend}
-                    hint={item.fieldset.hint}
-                    required={item.fieldset.required}
-                    requiredLabel={requiredLabel}
-                  >
-                    {item.fieldset.inputs.map((input, index) => {
-                      const fieldSetId = `${item.fieldset.criteriaKey}_${index}`
-                      return (
-                        <div key={fieldSetId}>
-                          <Date
-                            required={
-                              Object.keys(input.inputCriteria.values[0]?.value)
-                                .length < 3
-                                ? item.fieldset.required
-                                : 'FALSE'
-                            }
-                            value={input.inputCriteria.values[0]?.value}
-                            onChange={event =>
-                              handleDateChanged(
-                                event,
-                                item.fieldset.criteriaKey
-                              )
-                            }
-                            ui={ui}
-                          />
-                        </div>
-                      )
-                    })}
-                  </Fieldset>
-                ) : null
+                            </div>
+                          )
+                        })}
+                      </Fieldset>
+                      {children || null}
+                    </>
+                  ) : item.fieldset.inputs[0].inputCriteria.type === 'Radio' ? (
+                    //
+                    //
+                    // case radio
+                    //
+                    //
+                    <>
+                      <Fieldset
+                        key={`${item.fieldset.criteriaKey}-${index}`}
+                        legend={item.fieldset.legend}
+                        hint={item.fieldset.hint}
+                        required={item.fieldset.required}
+                        requiredLabel={requiredLabel}
+                      >
+                        {item.fieldset.inputs.map((input, index) => {
+                          const fieldSetId = `${item.fieldset.criteriaKey}_${index}`
+
+                          const inputValues = input.inputCriteria.values
+                          const optionSelected = inputValues.find(
+                            value => value.selected !== undefined
+                          )
+
+                          return (
+                            <div key={fieldSetId}>
+                              {/* map the options */}
+                              {input.inputCriteria.values.map(
+                                (option, index) => {
+                                  const inputId = `${fieldSetId}_${index}`
+
+                                  return (
+                                    <Radio
+                                      required={
+                                        !optionSelected &&
+                                        item.fieldset.required
+                                      }
+                                      id={inputId}
+                                      key={inputId}
+                                      label={option.value}
+                                      value={option.value}
+                                      checked={option.selected || false}
+                                      onChange={event => {
+                                        handleChanged(
+                                          event,
+                                          item.fieldset.criteriaKey
+                                        )
+                                      }}
+                                    />
+                                  )
+                                }
+                              )}
+                            </div>
+                          )
+                        })}
+                      </Fieldset>
+                      {children || null}
+                    </>
+                  ) : item.fieldset.inputs[0].inputCriteria.type === 'Date' ? (
+                    //
+                    //
+                    // case date
+                    //
+                    //
+                    <>
+                      <Fieldset
+                        key={`${item.fieldset.criteriaKey}-${index}`}
+                        legend={item.fieldset.legend}
+                        hint={item.fieldset.hint}
+                        required={item.fieldset.required}
+                        requiredLabel={requiredLabel}
+                      >
+                        {item.fieldset.inputs.map((input, index) => {
+                          const fieldSetId = `${item.fieldset.criteriaKey}_${index}`
+                          return (
+                            <div key={fieldSetId}>
+                              <Date
+                                required={
+                                  Object.keys(
+                                    input.inputCriteria.values[0]?.value
+                                  ).length < 3
+                                    ? item.fieldset.required
+                                    : 'FALSE'
+                                }
+                                value={input.inputCriteria.values[0]?.value}
+                                onChange={event =>
+                                  handleDateChanged(
+                                    event,
+                                    item.fieldset.criteriaKey
+                                  )
+                                }
+                                ui={ui}
+                              />
+                            </div>
+                          )
+                        })}
+                      </Fieldset>
+                      {children || null}
+                    </>
+                  ) : null
+
+                const parentElement = ({ item, i }) => Input({ item, index: i })
+
+                const parentWithChildElement = ({ item, i }) =>
+                  item.fieldset.children.map((child, i) => {
+                    return (
+                      child.fieldsets.length > 0 &&
+                      child.fieldsets.map((childItem, childItemIndex) => {
+                        return Input({
+                          item,
+                          index: i,
+                          children: Input({
+                            item: childItem,
+                            index: childItemIndex,
+                          }),
+                        })
+                      })
+                    )
+                  })
+
+                // children check
+                const fieldSet = () =>
+                  item.fieldset.children.length > 0
+                    ? parentWithChildElement({ item, i })
+                    : parentElement({ item, i })
+
+                return fieldSet()
               })}
             </div>
           )}

--- a/bears-app/src/shared/components/LifeEventSection/index.jsx
+++ b/bears-app/src/shared/components/LifeEventSection/index.jsx
@@ -252,10 +252,10 @@ const LifeEventSection = ({
               {/* TODO: create handler component for input case switching */}
 
               {currentData.section.fieldsets.map((item, i) => {
-                // TODO: exludes groups for now
-                if (item.fieldset.fieldsets) {
-                  return null
-                }
+                // // TODO: exludes groups for now
+                // if (item.fieldset.fieldsets) {
+                //   return null
+                // }
                 return item.fieldset.inputs[0].inputCriteria.type ===
                   'Select' ? (
                   //

--- a/bears-app/src/shared/components/ResultsView/__tests__/__snapshots__/index.spec.js.snap
+++ b/bears-app/src/shared/components/ResultsView/__tests__/__snapshots__/index.spec.js.snap
@@ -74,6 +74,7 @@ exports[`ResultsView renders a match to the previous snapshot 1`] = `
       />
       <button
         className=""
+        onClick={[Function]}
         type="button"
       >
         See benefits you did not qualify for

--- a/bears-app/src/shared/components/ResultsView/index.jsx
+++ b/bears-app/src/shared/components/ResultsView/index.jsx
@@ -119,39 +119,47 @@ const ResultsView = ({ handleStepBack, ui, data, stepDataArray }) => {
             )
 
             const checkForChildrenValues = item => {
-              let child
+              const children = []
               if (item.fieldset.children.length > 0) {
                 item.fieldset.children.forEach(childItem => {
-                  child =
+                  const check =
                     childItem.fieldsets[0].fieldset.inputs[0].inputCriteria.values.find(
-                      value => value.selected
+                      value => value.selected === true
                     )
+                  if (check) {
+                    const criteriaKey =
+                      childItem.fieldsets[0].fieldset.criteriaKey
+
+                    children.push({ criteriaKey, values: check })
+                  }
                 })
               }
-              return child
+              console.log('children', children)
+              return children && children
             }
 
-            const childCriteriaKey = item => {
-              let criteriaKey
-              if (item.fieldset.children.length > 0) {
-                item.fieldset.children.forEach(childItem => {
-                  criteriaKey = childItem.fieldsets[0].fieldset.criteriaKey
-                })
-              }
-              return criteriaKey
-            }
+            // const childCriteriaKey = item => {
+            //   // let criteriaKey
+            //   const criteriaKey = item
+
+            //   return criteriaKey
+            // }
+
+            console.log(checkForChildrenValues(item))
 
             return (
-              selected && [
+              selected &&
+              [
                 {
                   criteriaKey: item.fieldset.inputs[0].inputCriteria.id,
                   values: selected,
                 },
-                checkForChildrenValues(item) && {
-                  criteriaKey: childCriteriaKey(item),
-                  values: checkForChildrenValues(item),
-                },
-              ]
+                checkForChildrenValues(item) &&
+                  checkForChildrenValues(item).map((child, i) => ({
+                    criteriaKey: child.criteriaKey,
+                    values: child.values,
+                  })),
+              ].flat()
             )
           })
           .flat()
@@ -176,6 +184,7 @@ const ResultsView = ({ handleStepBack, ui, data, stepDataArray }) => {
   // check that the value === acceptable values
 
   const handleData = (selectedCriteria, data) => {
+    console.log(selectedCriteria)
     // return all eligible items
     const eligibleItems =
       data &&

--- a/bears-app/src/shared/components/ResultsView/index.jsx
+++ b/bears-app/src/shared/components/ResultsView/index.jsx
@@ -111,24 +111,50 @@ const ResultsView = ({ handleStepBack, ui, data, stepDataArray }) => {
     stepDataArray &&
     stepDataArray
       .map((item, i) =>
-        item.section.fieldsets.map(item => {
-          // // TODO: exludes groups for now
-          // if (item.fieldset.fieldsets) {
-          //   return undefined
-          // }
+        item.section.fieldsets
+          .map(item => {
+            // find selected values
+            const selected = item.fieldset.inputs[0].inputCriteria.values.find(
+              value => value.selected === true
+            )
 
-          // find selected values
-          const selected = item.fieldset.inputs[0].inputCriteria.values.find(
-            value => value.selected === true
-          )
-
-          return (
-            selected && {
-              criteriaKey: item.fieldset.inputs[0].inputCriteria.id,
-              values: selected,
+            const checkForChildrenValues = item => {
+              let child
+              if (item.fieldset.children.length > 0) {
+                item.fieldset.children.forEach(childItem => {
+                  child =
+                    childItem.fieldsets[0].fieldset.inputs[0].inputCriteria.values.find(
+                      value => value.selected
+                    )
+                })
+              }
+              return child
             }
-          )
-        })
+
+            const childCriteriaKey = item => {
+              let criteriaKey
+              if (item.fieldset.children.length > 0) {
+                item.fieldset.children.forEach(childItem => {
+                  criteriaKey = childItem.fieldsets[0].fieldset.criteriaKey
+                })
+              }
+              return criteriaKey
+            }
+
+            return (
+              selected && [
+                {
+                  criteriaKey: item.fieldset.inputs[0].inputCriteria.id,
+                  values: selected,
+                },
+                checkForChildrenValues(item) && {
+                  criteriaKey: childCriteriaKey(item),
+                  values: checkForChildrenValues(item),
+                },
+              ]
+            )
+          })
+          .flat()
       )
       .flat() // we flatten all to have only one array
       .filter(element => element !== undefined) // remove undefined

--- a/bears-app/src/shared/components/ResultsView/index.jsx
+++ b/bears-app/src/shared/components/ResultsView/index.jsx
@@ -54,7 +54,7 @@ const ResultsView = ({ handleStepBack, ui, data, stepDataArray }) => {
 
           return (
             selected && {
-              id: item.fieldset.inputs[0].inputCriteria.id,
+              criteriaKey: item.fieldset.inputs[0].inputCriteria.id,
               values: selected,
             }
           )
@@ -62,8 +62,6 @@ const ResultsView = ({ handleStepBack, ui, data, stepDataArray }) => {
       )
       .flat() // we flatten all to have only one array
       .filter(element => element !== undefined) // remove undefined
-
-  console.log('selected criteria', selectedCriteria)
 
   // Total Criteria = y
   // Met Criteria = x
@@ -81,18 +79,37 @@ const ResultsView = ({ handleStepBack, ui, data, stepDataArray }) => {
   // if there is a criteriakey match in a benefit
   // check that the value === acceptable values
 
-  // function likelyEligible(selectedCriteria, data) {
-  //   console.log(selectedCriteria)
-  //   data.forEach((item, i) => {
-  //     console.log(item.benefit.eligibility)
-  //   })
-  // }
+  const handleData = (selectedCriteria, data) => {
+    // return all eligible items
+    const eligibleItems =
+      data &&
+      data.map(item => {
+        console.log(item.benefit.eligibility)
+        // find all eligibility items that are matches to criteria key
+        const criteriaEligibility = item.benefit.eligibility.find(
+          criteria => criteria.criteriaKey === selectedCriteria[0].criteriaKey
+        )
 
-  // console.log(likelyEligible(selectedCriteria, data))
+        const isEligible =
+          criteriaEligibility !== undefined &&
+          criteriaEligibility.acceptableValues.find(
+            value => value === selectedCriteria[0].values.value
+          )
+
+        if (isEligible === selectedCriteria[0].values.value) {
+          criteriaEligibility.isEligible = true
+        }
+
+        return item
+      })
+    return eligibleItems
+  }
+
+  console.log('item matches', handleData(selectedCriteria, data))
 
   useEffect(() => {
     window.scrollTo(0, 0)
-  })
+  }, [data, selectedCriteria])
 
   // compare the selected criteria array with benefits
   return (
@@ -104,7 +121,11 @@ const ResultsView = ({ handleStepBack, ui, data, stepDataArray }) => {
         <p dangerouslySetInnerHTML={createMarkup(description)} />
         {/* map all the benefits into cards */}
         <div className="result-view-benefits">
-          <BenefitAccordionGroup data={data} entryKey={'benefit'} expandAll />
+          <BenefitAccordionGroup
+            data={handleData(selectedCriteria, data)}
+            entryKey={'benefit'}
+            expandAll
+          />
         </div>
         <div className="result-view-unmet">
           <Heading headingLevel={3}>{notEligibleResults?.heading}</Heading>

--- a/bears-app/src/shared/components/ResultsView/index.jsx
+++ b/bears-app/src/shared/components/ResultsView/index.jsx
@@ -134,18 +134,8 @@ const ResultsView = ({ handleStepBack, ui, data, stepDataArray }) => {
                   }
                 })
               }
-              console.log('children', children)
               return children && children
             }
-
-            // const childCriteriaKey = item => {
-            //   // let criteriaKey
-            //   const criteriaKey = item
-
-            //   return criteriaKey
-            // }
-
-            console.log(checkForChildrenValues(item))
 
             return (
               selected &&
@@ -184,7 +174,6 @@ const ResultsView = ({ handleStepBack, ui, data, stepDataArray }) => {
   // check that the value === acceptable values
 
   const handleData = (selectedCriteria, data) => {
-    console.log(selectedCriteria)
     // return all eligible items
     const eligibleItems =
       data &&

--- a/bears-app/src/shared/components/ResultsView/index.jsx
+++ b/bears-app/src/shared/components/ResultsView/index.jsx
@@ -148,7 +148,6 @@ const ResultsView = ({ handleStepBack, ui, data, stepDataArray }) => {
   // for each benefit eligiblity compare compare selectedCriteria
   // if there is a criteriakey match in a benefit
   // check that the value === acceptable values
-  console.log('data', data)
 
   const handleData = (selectedCriteria, data) => {
     // return all eligible items

--- a/bears-app/src/shared/components/ResultsView/index.jsx
+++ b/bears-app/src/shared/components/ResultsView/index.jsx
@@ -24,7 +24,7 @@ import './_index.scss'
  * @param {array} stepDataArray inherited state of inupt values from form entry
  * @return {html} returns a view page of filtered benefits
  */
-const ResultsView = ({ handleStepBack, ui, data }) => {
+const ResultsView = ({ handleStepBack, ui, data, stepDataArray }) => {
   // console.log(data)
   const {
     heading,
@@ -37,18 +37,33 @@ const ResultsView = ({ handleStepBack, ui, data }) => {
   } = ui
 
   // collect all the criteria keys and selected criteria values into an array
-  // const selectedCriteria = stepDataArray
-  //   .map((item, i) =>
-  //     item.section.fieldsets.map(item => {
-  //       return {
-  //         id: item.fieldset.inputs[0].inputCriteria.id,
-  //         values: item.fieldset.inputs[0].inputCriteria.values.find(
-  //           value => value.selected
-  //         ),
-  //       }
-  //     })
-  //   )
-  //   .flat() // we flatten all to have only one array
+  const selectedCriteria =
+    stepDataArray &&
+    stepDataArray
+      .map((item, i) =>
+        item.section.fieldsets.map(item => {
+          // TODO: exludes groups for now
+          if (item.fieldset.fieldsets) {
+            return undefined
+          }
+
+          // find selected values
+          const selected = item.fieldset.inputs[0].inputCriteria.values.find(
+            value => value.selected === true
+          )
+
+          return (
+            selected && {
+              id: item.fieldset.inputs[0].inputCriteria.id,
+              values: selected,
+            }
+          )
+        })
+      )
+      .flat() // we flatten all to have only one array
+      .filter(element => element !== undefined) // remove undefined
+
+  console.log('selected criteria', selectedCriteria)
 
   // Total Criteria = y
   // Met Criteria = x

--- a/bears-app/src/shared/components/VerifySelectionsView/index.jsx
+++ b/bears-app/src/shared/components/VerifySelectionsView/index.jsx
@@ -52,10 +52,10 @@ const VerifySelectionsView = ({
                     </Heading>
                     <div>
                       {section.fieldsets.map((item, i) => {
-                        // TODO: exludes groups for now
-                        if (item.fieldset.fieldsets) {
-                          return null
-                        }
+                        // // TODO: exludes groups for now
+                        // if (item.fieldset.fieldsets) {
+                        //   return null
+                        // }
                         const criteriaId = `criteria-${item.fieldset.criteriaKey}-${i}`
                         const result =
                           item.fieldset.inputs[0].inputCriteria.values.find(

--- a/bears-app/src/shared/components/VerifySelectionsView/index.jsx
+++ b/bears-app/src/shared/components/VerifySelectionsView/index.jsx
@@ -52,11 +52,41 @@ const VerifySelectionsView = ({
                     </Heading>
                     <div>
                       {section.fieldsets.map((item, i) => {
-                        // // TODO: exludes groups for now
-                        // if (item.fieldset.fieldsets) {
-                        //   return null
-                        // }
-                        const criteriaId = `criteria-${item.fieldset.criteriaKey}-${i}`
+                        // check if children values
+                        const checkForChildrenValues = item => {
+                          let child
+                          if (item.fieldset.children.length > 0) {
+                            item.fieldset.children.forEach(childItem => {
+                              child =
+                                childItem.fieldsets[0].fieldset.inputs[0].inputCriteria.values.find(
+                                  value => value.selected
+                                )
+                            })
+                          }
+                          return child
+                        }
+
+                        const childrenLegend = item => {
+                          let legend
+                          if (item.fieldset.children.length > 0) {
+                            item.fieldset.children.forEach(childItem => {
+                              legend = childItem.fieldsets[0].fieldset.legend
+                            })
+                          }
+                          return legend
+                        }
+
+                        const childrenCriteriaKey = item => {
+                          let criteriaKey
+                          if (item.fieldset.children.length > 0) {
+                            item.fieldset.children.forEach(childItem => {
+                              criteriaKey =
+                                childItem.fieldsets[0].fieldset.criteriaKey
+                            })
+                          }
+                          return criteriaKey
+                        }
+
                         const result =
                           item.fieldset.inputs[0].inputCriteria.values.find(
                             value => value.selected
@@ -76,29 +106,53 @@ const VerifySelectionsView = ({
                           day: 'numeric',
                         }
 
+                        const resultItem = ({ criteriaId, legend, result }) => {
+                          return (
+                            <div className="verify-criteria-value">
+                              <div
+                                className="verify-criteria-legend"
+                                key={criteriaId}
+                              >
+                                {legend}
+                              </div>
+                              {typeof result?.value === 'object'
+                                ? `${parseDate(result.value).toLocaleDateString(
+                                    undefined,
+                                    dateFormatOptions
+                                  )}`
+                                : result?.value}
+                            </div>
+                          )
+                        }
+
+                        const Items = ({ item, result }) => {
+                          return (
+                            <div>
+                              {resultItem({
+                                criteriaId: `criteria-${item.fieldset.criteriaKey}-${i}`,
+                                legend: item.fieldset.legend,
+                                result,
+                              })}
+                              {checkForChildrenValues(item) &&
+                                resultItem({
+                                  criteriaId: childrenCriteriaKey(item),
+                                  legend: childrenLegend(item),
+                                  result: checkForChildrenValues(item),
+                                })}
+                            </div>
+                          )
+                        }
+
                         // if no value then return generic message
                         return result !== undefined ? (
-                          <div className="verify-criteria-value">
-                            <div
-                              className="verify-criteria-legend"
-                              key={`${criteriaId}`}
-                            >
-                              {`${item.fieldset.legend}:`}
-                            </div>
-                            {typeof result.value === 'object'
-                              ? `${parseDate(result.value).toLocaleDateString(
-                                  undefined,
-                                  dateFormatOptions
-                                )}`
-                              : result.value}
-                          </div>
+                          <Items item={item} result={result} />
                         ) : (
                           <div className="verify-criteria-value">
                             <div
                               className="verify-criteria-legend"
-                              key={`${criteriaId}`}
+                              key={`criteria-${item.fieldset.criteriaKey}-${i}`}
                             >
-                              {`${item.fieldset.legend}:`}
+                              {item.fieldset.legend}
                             </div>
                             No input given.
                           </div>

--- a/bears-app/src/shared/locales/en/en.json
+++ b/bears-app/src/shared/locales/en/en.json
@@ -72,12 +72,22 @@
     ]
   },
   "resultsView": {
-    "chevron": {
-      "heading": "Your Custom List",
-      "description": "<div><p><strong>Here is your list of potential Federal Benefits.</strong> Your state, city or employer may offer other benefits.Visit each agency providing the benefit to learn if you are truly eligible and conduct an actual applications.</p></div>"
+    "qualified": {
+      "chevron": {
+        "heading": "Your Custom List",
+        "description": "<div><p><strong>Here is your list of potential Federal Benefits.</strong> Your state, city or employer may offer other benefits.Visit each agency providing the benefit to learn if you are truly eligible and conduct an actual applications.</p></div>"
+      },
+      "heading": "Results",
+      "description": "<div><strong>Based on your answers you meet the criteria to qualify for these benefits:</strong></div>"
     },
-    "heading": "Results",
-    "description": "<div><strong>Based on your answers you meet the criteria to qualify for these benefits:</strong></div>",
+    "notQualified": {
+      "chevron": {
+        "heading": "Your Custom List",
+        "description": "<div><p><strong>Here is your list of potential Federal Benefits.</strong> Your state, city or employer may offer other benefits.Visit each agency providing the benefit to learn if you are truly eligible and conduct an actual applications.</p></div>"
+      },
+      "heading": "Results",
+      "description": "<div><strong>Based on your answers you meet the criteria to qualify for these benefits:</strong></div>"
+    },
     "stepBackLink": "Back",
     "eligibleResults": {
       "heading": "Results",

--- a/bears-app/src/shared/locales/es/es.json
+++ b/bears-app/src/shared/locales/es/es.json
@@ -72,12 +72,22 @@
     ]
   },
   "resultsView": {
-    "chevron": {
-      "heading": "Sus beneficios potenciales",
-      "description": "<div><p>Necesita verificar los requisitos y visitar la página de cada agencia para aplicar.<strong> Para conocer otros beneficios, consulte a su ciudad, estado, o trabajo.</strong></p></div>"
+    "qualified": {
+      "chevron": {
+        "heading": "Sus beneficios potenciales",
+        "description": "<div><p>Necesita verificar los requisitos y visitar la página de cada agencia para aplicar.<strong> Para conocer otros beneficios, consulte a su ciudad, estado, o trabajo.</strong></p></div>"
+      },
+      "heading": "Resultados",
+      "description": "<div><strong>Usted puede calificar para los siguientes beneficios:<strong/></div>"
     },
-    "heading": "Resultados",
-    "description": "<div><strong>Usted puede calificar para los siguientes beneficios:<strong/></div>",
+    "notQualified": {
+      "chevron": {
+        "heading": "Sus beneficios potenciales",
+        "description": "<div><p>Aquí hay una lista de beneficios federales para los que no calificó.<strong> Para conocer otros beneficios, consulte a su ciudad, estado, o trabajo.</strong></p></div>"
+      },
+      "heading": "Resultados",
+      "description": "<div><strong>De acuerdo a sus respuestas usted no cumple con los requisitos para acceder a estos beneficios:<strong/></div>"
+    },
     "stepBackLink": "Volver",
     "eligibleResults": {
       "heading": "Resultados",


### PR DESCRIPTION
## PR Summary

Include a summary of the change, relevant motivation, and context.

## Related Github Issue

- fixes #298 
- fixes #296 
- fixes #276 

## Detailed Testing steps

- [ ] cd bears-app
- [ ] npm install
- [ ] npm run start
- [ ] navigate through the form entering information for all fields


[As a user, on a life event form, I may need to answer additional questions if the value of a parent question reveals related child questions from within the same step](https://github.com/GSA/px-bears-drupal/issues/296)	https://github.com/GSA/px-bears-drupal/issues/296

- [ ] when you get to the last question of the last section

> Did the deceased serve in the active military, naval, or air service?

- [ ] confirm that selecting "Yes" renders additional child questions below
- [ ] confirm that selecting "No" removes the child questions from display


https://github.com/GSA/px-bears-drupal/assets/37077057/9577533b-3f24-425b-b8d0-cdb6cb6b23e1


[As a user, after completing a life event form, I need to clearly see benefits I may qualify for based on my selections](https://github.com/GSA/px-bears-drupal/issues/276)	https://github.com/GSA/px-bears-drupal/issues/276

- [ ] select "Continue" at the end of the form
- [ ] select "See Results"
- [ ] confirm that the view only displays "Likely Eligible" Items
- [ ] expand all the Benefit Accordions
- [ ] confirm that the selections made in the form match the results in the first accordion

[As a user, after completing a life event form, I need to be able to see other potential benefits that I did not qualify for](https://github.com/GSA/px-bears-drupal/issues/298)	https://github.com/GSA/px-bears-drupal/issues/298

- [ ] scroll down and click the Button "See benefits you did not qualify for"
- [ ] confirm that the new view renders only "Not Eligible", and "More Information Needed" items
- [ ] select "Expand all"
- [ ] confirm that the selections made in the form match the results in the first accordion labeled "Not Eligible"
- [ ] confirm that the selections made in the form match the results in the first accordion labeled "More Information Needed"
