### PR TITLE
[409] - Create script to use awscli commands for s3 in cloud.gov

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,51 @@ cd bin/cloudgov
 ./db-backup.sh
 ```
 
+### How to use awscli commands for s3 
+
+1. Make sure you login cloud.gov on your terminal and target your org and space.
+
+```
+cf login -a api.fr.cloud.gov --sso
+```
+
+2. Change directory to where the script lives.
+
+```
+cd bin/cloudgov
+```
+
+3. Export the bucket name in your terminal
+
+```
+export bucket_name=storage or export bucket_name=dbstorage 
+```
+
+4. Execute the following script. Make sure you `source` it!
+
+```
+source ./cloudgov-aws-creds.sh 
+```
+5. If you see the script finds a key and deletes it; make sure you run it again to create the key again. If the script finds a key, it will delete it.
+
+You'll see either of the below messages after running it. 
+
+```
+Getting bucket credentials...
+Key found. Deleting...
+
+or
+
+Getting bucket credentials...
+Key not found. Creating...
+```
+6. Start using `aws s3` commands like below:
+
+```
+aws s3 ls s3://${AWS_BUCKET}/
+```
+
+7. Run it again after using it to delete the service-key.
 
 # VDI Login Guide for the BEARS Team Members
 ## What is VDI?

--- a/bin/cloudgov/cloudgov-aws-creds.sh
+++ b/bin/cloudgov/cloudgov-aws-creds.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+current_path=$(pwd)
+
+[ -z "${bucket_name}" ] && echo "No bucket name!" && help && exit 1
+
+echo "Getting bucket credentials..."
+{
+  current_space=$(cf target | grep space | awk '{print $2}')
+
+  cf target -s "${deploy_space}"
+  
+  service_key="${bucket_name}-key"
+  s3_credentials=$(cf service-key "${bucket_name}" "${service_key}" | tail -n +2)
+} >/dev/null 2>&1
+
+if [ "${s3_credentials}" = "FAILED" ] ; then
+  echo "Key not found. Creating..."
+  {
+    cf create-service-key "${bucket_name}" "${service_key}"
+    s3_credentials=$(cf service-key "${bucket_name}" "${service_key}" | tail -n +2)
+    aws_access_key=$(echo "${s3_credentials}" | jq -r '.credentials.access_key_id')
+    aws_bucket_name=$(echo "${s3_credentials}" | jq -r '.credentials.bucket')
+    aws_bucket_region=$(echo "${s3_credentials}" | jq -r '.credentials.region')
+    aws_secret_key=$(echo "${s3_credentials}" | jq -r '.credentials.secret_access_key')
+    export AWS_ACCESS_KEY_ID=${aws_access_key}
+    export AWS_BUCKET=${aws_bucket_name}
+    export AWS_DEFAULT_REGION=${aws_bucket_region}
+    export AWS_SECRET_ACCESS_KEY=${aws_secret_key}
+
+    cf target -s "${current_space}"
+
+  } >/dev/null 2>&1
+else
+  echo "Key found. Deleting..."
+  {
+    current_space=$(cf target | grep space | awk '{print $2}')
+    
+    cf target -s "${cf_space}"
+
+    cf delete-service-key "${bucket_name}" "${service_key}" -f
+
+    cf target -s "${current_space}"
+    
+  } >/dev/null 2>&1
+fi


### PR DESCRIPTION
## PR Summary

This PR creates a script that creates a service-key for us to be able to utilize to use aws s3 commands in cloud.gov.

## Related Github Issue

- fixes #[Create script to use awscli commands against s3 in cloud.gov#409](https://github.com/GSA/px-bears-drupal/issues/409)

## Detailed Testing steps

Link to testing steps in the issue or list them here:

1. Make sure you login cloud.gov on your terminal and target your org and space.

```
cf login -a api.fr.cloud.gov --sso
```

2. Change directory to where the script lives.

```
cd bin/cloudgov
```

3. Export the bucket name in your terminal

```
export bucket_name=storage or export bucket_name=dbstorage 
```

4. Execute the following script. Make sure you `source` it!

```
source ./cloudgov-aws-creds.sh 
```
5. If you see the script finds a key and deletes it; make sure you run it again to create the key again. If the script finds a key, it will delete it.

You'll see either of the below messages after running it. 

```
Getting bucket credentials...
Key found. Deleting...

or

Getting bucket credentials...
Key not found. Creating...
```
6. Start using `aws s3` commands like below:

```
aws s3 ls s3://${AWS_BUCKET}/
```

7. Run it again after using it to delete the service-key.
