### PR TITLE
Update building json data file process

### DIFF
--- a/usagov_bears/modules/usagov_bears_api/src/Controller/LifeEventController.php
+++ b/usagov_bears/modules/usagov_bears_api/src/Controller/LifeEventController.php
@@ -187,6 +187,23 @@ class LifeEventController {
   }
 
   /**
+   * Gets life event of given ID.
+   * @param $id
+   * @return \Drupal\node\NodeInterface
+   *   The life event node.
+   */
+  public function getLifeEvent($id) {
+    $query = \Drupal::entityQuery('node')
+      ->condition('type', 'bears_life_event')
+      ->condition('field_b_id', $id)
+      ->range(0, 1);
+    $node_id = current($query->execute());
+    $service = $this->entityTypeManager->getStorage('node');
+    $node = $service->load($node_id);
+    return $node;
+  }
+
+  /**
    * Gets life event form of given ID.
    * @param $id
    * @return \Drupal\node\NodeInterface

--- a/usagov_bears/modules/usagov_bears_api/src/Controller/LifeEventController.php
+++ b/usagov_bears/modules/usagov_bears_api/src/Controller/LifeEventController.php
@@ -65,7 +65,7 @@ class LifeEventController {
     $this->fileSystem->prepareDirectory($directory, FileSystemInterface:: CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS);
 
     // Get JSON data.
-    $data = new JsonResponse([
+    $data = json_encode([
         'data' => $this->getData($id),
         'method' => 'GET',
         'status' => 200
@@ -75,8 +75,17 @@ class LifeEventController {
     // Write JSON data file.
     $filename = "$directory/$id.json";
     $file = $this->fileRepository->writeData($data, $filename, FileSystemInterface::EXISTS_REPLACE);
-
     $fileUrlString = $this->fileUrlGenerator->generate($filename)->toString();
+
+    // Assign the file to JSON data file field of life event of given ID.
+    $life_event = $this->getLifeEvent($id);
+    if ($life_event) {
+      $life_event->set('field_json_data_file', [
+        'target_id' => $file->id(),
+      ]);
+      $life_event->save();
+    }
+
     return new JsonResponse([
         'data' => "Saved JSON data to " . $fileUrlString,
         'method' => 'GET',


### PR DESCRIPTION
## PR Summary

This PR updates building json data file process.

- Remove header of json data file.
- Assign the json data file to life event.

## Related Github Issue

## Detailed Testing steps

In local or sandbox, 

Navigate to http://benefit-finder-site/bears/api/life-event/{id}/jsonfile
{id} is life event ID, for example, death, retirement, disability.

It saves json data file without header.
For example, the life event "death" json data file has no header.
/sites/default/files/bears/api/life_event/death.json