### PR TITLE
372 remove header of json data file

### DIFF
--- a/usagov_bears/modules/usagov_bears_api/src/Controller/LifeEventController.php
+++ b/usagov_bears/modules/usagov_bears_api/src/Controller/LifeEventController.php
@@ -65,7 +65,7 @@ class LifeEventController {
     $this->fileSystem->prepareDirectory($directory, FileSystemInterface:: CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS);
 
     // Get JSON data.
-    $data = new JsonResponse([
+    $data = json_encode([
         'data' => $this->getData($id),
         'method' => 'GET',
         'status' => 200


### PR DESCRIPTION
## PR Summary

This PR removes the header of JSON data file.

## Related Github Issue

- fixes #372 

## Detailed Testing steps

In local or sandbox, 

Navigate to http://benefit-finder-site/bears/api/life-event/{id}/jsonfile
{id} is life event ID, for example, death, retirement, disability.

It saves json data file without header.
For example, the life event "death" json data file has no header.
/sites/default/files/bears/api/life_event/death.json