### PR TITLE
450 data validation date input

### DIFF
--- a/benefit-finder/src/shared/components/Date/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/Date/__tests__/__snapshots__/index.spec.js.snap
@@ -103,9 +103,7 @@ exports[`Date renders a match to the previous snapshot 1`] = `
       className="usa-input "
       id="date_of_birth_day"
       inputMode="numeric"
-      maxLength="2"
       name="date_of_birth_day"
-      pattern="[0-9]*"
       value=""
     />
   </div>
@@ -123,10 +121,7 @@ exports[`Date renders a match to the previous snapshot 1`] = `
       className="usa-input "
       id="date_of_birth_year"
       inputMode="numeric"
-      maxLength="4"
-      minLength="4"
       name="date_of_birth_year"
-      pattern="[0-9]*"
       value=""
     />
   </div>

--- a/benefit-finder/src/shared/components/Date/index.jsx
+++ b/benefit-finder/src/shared/components/Date/index.jsx
@@ -53,8 +53,6 @@ const Date = ({ onChange, value, required, ui }) => {
           aria-describedby="mdHint"
           id="date_of_birth_day"
           name="date_of_birth_day"
-          maxLength="2"
-          pattern="[0-9]*"
           inputMode="numeric"
           value={(value && value.day) || ''}
           onChange={onChange}
@@ -69,9 +67,6 @@ const Date = ({ onChange, value, required, ui }) => {
           aria-describedby="mdHint"
           id="date_of_birth_year"
           name="date_of_birth_year"
-          minLength="4"
-          maxLength="4"
-          pattern="[0-9]*"
           inputMode="numeric"
           value={(value && value.year) || ''}
           onChange={onChange}

--- a/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.js.snap
@@ -213,10 +213,8 @@ Array [
                   className="usa-input required-field"
                   id="date_of_birth_day"
                   inputMode="numeric"
-                  maxLength="2"
                   name="date_of_birth_day"
                   onChange={[Function]}
-                  pattern="[0-9]*"
                   value=""
                 />
               </div>
@@ -234,11 +232,8 @@ Array [
                   className="usa-input required-field"
                   id="date_of_birth_year"
                   inputMode="numeric"
-                  maxLength="4"
-                  minLength="4"
                   name="date_of_birth_year"
                   onChange={[Function]}
-                  pattern="[0-9]*"
                   value=""
                 />
               </div>

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import createMarkup from '../../utils/createMarkup'
+import { dateInputValidation } from '../../utils/inputValidation'
 import * as apiCalls from '../../api/apiCalls'
 import {
   Alert,
@@ -164,31 +165,6 @@ const LifeEventSection = ({
     )
   }
 
-  const handleInputValidation = event => {
-    if (/^[0-9]*$/.test(`${event.target.value}`)) {
-      if (event.target.id.includes('day')) {
-        if (event.target.value.length === 2) {
-          return /^(0?[1-9]|[12][0-9]|3[01])$/.test(`${event.target.value}`)
-        }
-        return event.target.value.length < 3
-      }
-      if (event.target.id.includes('year')) {
-        // if (/^[0-9]*$/.test(`${event.target.value}`)) {
-        if (event.target.value.length === 4) {
-          return /^(19[0-9][0-9]|200[0-9]|202[0-3])$/.test(
-            `${event.target.value}`
-          )
-        }
-        return event.target.value.length < 5
-        // }
-      }
-    }
-
-    if (event.target.id.includes('month')) {
-      return event.target.value.length === 1
-    }
-  }
-
   /**
    * a function that handles the current selected value of our radio
    * and clears validation error if resolved
@@ -196,7 +172,7 @@ const LifeEventSection = ({
    * @return {object} object as state
    */
   const handleDateChanged = (event, criteriaKey) => {
-    handleInputValidation(event) === true &&
+    dateInputValidation(event) === true &&
       apiCalls.PUT.DataDate(
         criteriaKey,
         currentData,
@@ -204,6 +180,13 @@ const LifeEventSection = ({
         event.target.value,
         event.target.id
       )
+  }
+
+  const handleDateRequiered = (values, item) => {
+    return Object.keys(values?.value).length < 3 &&
+      values?.value?.year?.length !== 4
+      ? item.fieldset.required
+      : 'FALSE'
   }
 
   // manage the display of our modal initializer
@@ -383,15 +366,10 @@ const LifeEventSection = ({
                             return (
                               <div key={fieldSetId}>
                                 <Date
-                                  required={
-                                    Object.keys(
-                                      input.inputCriteria.values[0]?.value
-                                    ).length < 3 &&
-                                    input.inputCriteria.values[0]?.value?.year
-                                      ?.length !== 4
-                                      ? item.fieldset.required
-                                      : 'FALSE'
-                                  }
+                                  required={handleDateRequiered(
+                                    input.inputCriteria.values[0],
+                                    item
+                                  )}
                                   value={input.inputCriteria.values[0]?.value}
                                   onChange={event =>
                                     handleDateChanged(

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -164,6 +164,31 @@ const LifeEventSection = ({
     )
   }
 
+  const handleInputValidation = event => {
+    if (/^[0-9]*$/.test(`${event.target.value}`)) {
+      if (event.target.id.includes('day')) {
+        if (event.target.value.length === 2) {
+          return /^(0?[1-9]|[12][0-9]|3[01])$/.test(`${event.target.value}`)
+        }
+        return event.target.value.length < 3
+      }
+      if (event.target.id.includes('year')) {
+        // if (/^[0-9]*$/.test(`${event.target.value}`)) {
+        if (event.target.value.length === 4) {
+          return /^(19[0-9][0-9]|200[0-9]|202[0-3])$/.test(
+            `${event.target.value}`
+          )
+        }
+        return event.target.value.length < 5
+        // }
+      }
+    }
+
+    if (event.target.id.includes('month')) {
+      return event.target.value.length === 1
+    }
+  }
+
   /**
    * a function that handles the current selected value of our radio
    * and clears validation error if resolved
@@ -171,13 +196,14 @@ const LifeEventSection = ({
    * @return {object} object as state
    */
   const handleDateChanged = (event, criteriaKey) => {
-    apiCalls.PUT.DataDate(
-      criteriaKey,
-      currentData,
-      setCurrentData,
-      event.target.value,
-      event.target.id
-    )
+    handleInputValidation(event) === true &&
+      apiCalls.PUT.DataDate(
+        criteriaKey,
+        currentData,
+        setCurrentData,
+        event.target.value,
+        event.target.id
+      )
   }
 
   // manage the display of our modal initializer
@@ -360,7 +386,9 @@ const LifeEventSection = ({
                                   required={
                                     Object.keys(
                                       input.inputCriteria.values[0]?.value
-                                    ).length < 3
+                                    ).length < 3 &&
+                                    input.inputCriteria.values[0]?.value?.year
+                                      ?.length !== 4
                                       ? item.fieldset.required
                                       : 'FALSE'
                                   }

--- a/benefit-finder/src/shared/utils/inputValidation.js
+++ b/benefit-finder/src/shared/utils/inputValidation.js
@@ -1,0 +1,27 @@
+export const dateInputValidation = event => {
+  if (/^[0-9]*$/.test(`${event.target.value}`)) {
+    if (event.target.id.includes('day')) {
+      if (event.target.value.length === 2) {
+        const range = /^(0?[1-9]|[12][0-9]|3[01])$/
+        return range.test(`${event.target.value}`)
+      }
+      return event.target.value.length < 3
+    }
+    if (event.target.id.includes('year')) {
+      const currentYear = new Date().getFullYear().toString()
+      const yearLimit = currentYear.substring(currentYear.length - 1)
+      if (event.target.value.length === 4) {
+        // 1900 - currentyear
+        const range = new RegExp(
+          `^(19[0-9][0-9]|200[0-9]|202[0-${yearLimit}])$`
+        )
+        return range.test(`${event.target.value}`)
+      }
+      return event.target.value.length < 5
+    }
+  }
+
+  if (event.target.id.includes('month')) {
+    return event.target.value.length === 1
+  }
+}


### PR DESCRIPTION
## PR Summary

This includes the beginnings of additional functionality to try and limit input values in the "day" and "year" fields of our Date component.

| input | validation |
|------|-------|
| day | only numbers |
| day | range 0-31 |
| year | only numbers  |
| year | range 1900-current year |

Expected behavior
- invalid values will throw errors only when a user tries to navigate forward

## Related Github Issue

- fixes #450 

## Detailed Testing steps

Link to testing steps in the issue or list them here:

- [ ]  you will need to have form data available in your local Drupal instance to test https://bears-waf.app.cloud.gov/sites/default/files/bears/api/life_event/death.json
- [ ]  start the drupal server locally
- [ ]  start the application locally
- [ ] navigate to the first step and find a required date field
- [ ] find the day input and attempt to enter values that are not in the validation table above
- [ ] find the year input and attempt to enter values that are not in the validation table above
- [ ] clear the inputs
- [ ] attempt to continue
- [ ] confirm error state
- [ ] select month, enter valid day, enter invalid year
- [ ] attempt to continue
- [ ] confirm error state persists
- [ ] update valid year
- [ ] confirm error state removed
- [ ] if all required fields are correctly complete, attempt to continue
- [ ] confirm navigation forward successful