### PR TITLE
508 a11y tab order

### DIFF
--- a/benefit-finder/src/shared/components/Card/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/Card/__tests__/__snapshots__/index.spec.js.snap
@@ -13,6 +13,7 @@ exports[`Card renders a match to the previous snapshot 1`] = `
       >
         <h3
           className=""
+          id=""
         />
       </div>
       <p

--- a/benefit-finder/src/shared/components/Chevron/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/Chevron/__tests__/__snapshots__/index.spec.js.snap
@@ -9,6 +9,7 @@ exports[`Chevron renders a match to the previous snapshot 1`] = `
   >
     <h1
       className=""
+      id="skip-to-h1"
     />
     <div
       dangerouslySetInnerHTML={

--- a/benefit-finder/src/shared/components/Heading/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/Heading/__tests__/__snapshots__/index.spec.js.snap
@@ -3,5 +3,6 @@
 exports[`Heading renders a match to the previous snapshot 1`] = `
 <h1
   className=""
+  id="skip-to-h1"
 />
 `;

--- a/benefit-finder/src/shared/components/Heading/index.jsx
+++ b/benefit-finder/src/shared/components/Heading/index.jsx
@@ -19,6 +19,7 @@ const Heading = ({ children, className, headingLevel, ...props }) => {
   return (
     <Tag
       className={useHandleClassName({ className, defaultClasses })}
+      id={headingLevel === 1 ? 'skip-to-h1' : ''}
       {...props}
     >
       {children}

--- a/benefit-finder/src/shared/components/Intro/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/Intro/__tests__/__snapshots__/index.spec.js.snap
@@ -12,6 +12,7 @@ exports[`Intro renders a match to the previous snapshot 1`] = `
     >
       <h1
         className=""
+        id="skip-to-h1"
       >
         NEW Find federal benefits after the loss of a loved one
       </h1>
@@ -29,6 +30,7 @@ exports[`Intro renders a match to the previous snapshot 1`] = `
   >
     <h2
       className=""
+      id=""
     >
       Steps
     </h2>
@@ -82,6 +84,7 @@ exports[`Intro renders a match to the previous snapshot 1`] = `
       >
         <h2
           className=""
+          id=""
         >
           Before you start:
         </h2>

--- a/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.js.snap
@@ -371,6 +371,7 @@ Array [
               <input
                 checked={false}
                 className=""
+                id="applicant_citizen_status_0_0"
                 name="applicant_citizen_status_0"
                 onChange={[Function]}
                 type="radio"
@@ -378,6 +379,7 @@ Array [
               />
               <label
                 className=""
+                htmlFor="applicant_citizen_status_0_0"
               >
                 Yes
               </label>
@@ -388,6 +390,7 @@ Array [
               <input
                 checked={false}
                 className=""
+                id="applicant_citizen_status_0_1"
                 name="applicant_citizen_status_0"
                 onChange={[Function]}
                 type="radio"
@@ -395,6 +398,7 @@ Array [
               />
               <label
                 className=""
+                htmlFor="applicant_citizen_status_0_1"
               >
                 No
               </label>
@@ -418,6 +422,7 @@ Array [
               <input
                 checked={false}
                 className=""
+                id="applicant_care_for_child_0_0"
                 name="applicant_care_for_child_0"
                 onChange={[Function]}
                 type="radio"
@@ -425,6 +430,7 @@ Array [
               />
               <label
                 className=""
+                htmlFor="applicant_care_for_child_0_0"
               >
                 Yes
               </label>
@@ -435,6 +441,7 @@ Array [
               <input
                 checked={false}
                 className=""
+                id="applicant_care_for_child_0_1"
                 name="applicant_care_for_child_0"
                 onChange={[Function]}
                 type="radio"
@@ -442,6 +449,7 @@ Array [
               />
               <label
                 className=""
+                htmlFor="applicant_care_for_child_0_1"
               >
                 No
               </label>
@@ -465,6 +473,7 @@ Array [
               <input
                 checked={false}
                 className=""
+                id="applicant_paid_funeral_expenses_0_0"
                 name="applicant_paid_funeral_expenses_0"
                 onChange={[Function]}
                 type="radio"
@@ -472,6 +481,7 @@ Array [
               />
               <label
                 className=""
+                htmlFor="applicant_paid_funeral_expenses_0_0"
               >
                 Yes
               </label>
@@ -482,6 +492,7 @@ Array [
               <input
                 checked={false}
                 className=""
+                id="applicant_paid_funeral_expenses_0_1"
                 name="applicant_paid_funeral_expenses_0"
                 onChange={[Function]}
                 type="radio"
@@ -489,6 +500,7 @@ Array [
               />
               <label
                 className=""
+                htmlFor="applicant_paid_funeral_expenses_0_1"
               >
                 No
               </label>
@@ -512,6 +524,7 @@ Array [
               <input
                 checked={false}
                 className=""
+                id="applicant_funeral_reimbursement_0_0"
                 name="applicant_funeral_reimbursement_0"
                 onChange={[Function]}
                 type="radio"
@@ -519,6 +532,7 @@ Array [
               />
               <label
                 className=""
+                htmlFor="applicant_funeral_reimbursement_0_0"
               >
                 Yes
               </label>
@@ -529,6 +543,7 @@ Array [
               <input
                 checked={false}
                 className=""
+                id="applicant_funeral_reimbursement_0_1"
                 name="applicant_funeral_reimbursement_0"
                 onChange={[Function]}
                 type="radio"
@@ -536,6 +551,7 @@ Array [
               />
               <label
                 className=""
+                htmlFor="applicant_funeral_reimbursement_0_1"
               >
                 No
               </label>

--- a/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.js.snap
@@ -4,6 +4,7 @@ exports[`LifeEventSection renders a match to the previous snapshot 1`] = `
 Array [
   <h1
     className=""
+    id="skip-to-h1"
   >
     Complete Questions
   </h1>,
@@ -84,6 +85,7 @@ Array [
         </div>
         <h2
           className=""
+          id=""
         >
           About the applicant
         </h2>
@@ -369,15 +371,13 @@ Array [
               <input
                 checked={false}
                 className=""
-                id="applicant_citizen_status_0_0"
-                name="applicant_citizen_status_0_0"
+                name="applicant_citizen_status_0"
                 onChange={[Function]}
                 type="radio"
                 value="Yes"
               />
               <label
                 className=""
-                htmlFor="applicant_citizen_status_0_0"
               >
                 Yes
               </label>
@@ -388,15 +388,13 @@ Array [
               <input
                 checked={false}
                 className=""
-                id="applicant_citizen_status_0_1"
-                name="applicant_citizen_status_0_1"
+                name="applicant_citizen_status_0"
                 onChange={[Function]}
                 type="radio"
                 value="No"
               />
               <label
                 className=""
-                htmlFor="applicant_citizen_status_0_1"
               >
                 No
               </label>
@@ -420,15 +418,13 @@ Array [
               <input
                 checked={false}
                 className=""
-                id="applicant_care_for_child_0_0"
-                name="applicant_care_for_child_0_0"
+                name="applicant_care_for_child_0"
                 onChange={[Function]}
                 type="radio"
                 value="Yes"
               />
               <label
                 className=""
-                htmlFor="applicant_care_for_child_0_0"
               >
                 Yes
               </label>
@@ -439,15 +435,13 @@ Array [
               <input
                 checked={false}
                 className=""
-                id="applicant_care_for_child_0_1"
-                name="applicant_care_for_child_0_1"
+                name="applicant_care_for_child_0"
                 onChange={[Function]}
                 type="radio"
                 value="No"
               />
               <label
                 className=""
-                htmlFor="applicant_care_for_child_0_1"
               >
                 No
               </label>
@@ -471,15 +465,13 @@ Array [
               <input
                 checked={false}
                 className=""
-                id="applicant_paid_funeral_expenses_0_0"
-                name="applicant_paid_funeral_expenses_0_0"
+                name="applicant_paid_funeral_expenses_0"
                 onChange={[Function]}
                 type="radio"
                 value="Yes"
               />
               <label
                 className=""
-                htmlFor="applicant_paid_funeral_expenses_0_0"
               >
                 Yes
               </label>
@@ -490,15 +482,13 @@ Array [
               <input
                 checked={false}
                 className=""
-                id="applicant_paid_funeral_expenses_0_1"
-                name="applicant_paid_funeral_expenses_0_1"
+                name="applicant_paid_funeral_expenses_0"
                 onChange={[Function]}
                 type="radio"
                 value="No"
               />
               <label
                 className=""
-                htmlFor="applicant_paid_funeral_expenses_0_1"
               >
                 No
               </label>
@@ -522,15 +512,13 @@ Array [
               <input
                 checked={false}
                 className=""
-                id="applicant_funeral_reimbursement_0_0"
-                name="applicant_funeral_reimbursement_0_0"
+                name="applicant_funeral_reimbursement_0"
                 onChange={[Function]}
                 type="radio"
                 value="Yes"
               />
               <label
                 className=""
-                htmlFor="applicant_funeral_reimbursement_0_0"
               >
                 Yes
               </label>
@@ -541,15 +529,13 @@ Array [
               <input
                 checked={false}
                 className=""
-                id="applicant_funeral_reimbursement_0_1"
-                name="applicant_funeral_reimbursement_0_1"
+                name="applicant_funeral_reimbursement_0"
                 onChange={[Function]}
                 type="radio"
                 value="No"
               />
               <label
                 className=""
-                htmlFor="applicant_funeral_reimbursement_0_1"
               >
                 No
               </label>

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -331,6 +331,7 @@ const LifeEventSection = ({
                                         }
                                         name={fieldSetId}
                                         key={inputId}
+                                        id={inputId}
                                         label={option.value}
                                         value={option.value}
                                         checked={option.selected || false}

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -329,7 +329,7 @@ const LifeEventSection = ({
                                           !optionSelected &&
                                           item.fieldset.required
                                         }
-                                        id={inputId}
+                                        name={fieldSetId}
                                         key={inputId}
                                         label={option.value}
                                         value={option.value}

--- a/benefit-finder/src/shared/components/Modal/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/Modal/__tests__/__snapshots__/index.spec.js.snap
@@ -7,6 +7,8 @@ exports[`Modal renders a match to the previous snapshot 1`] = `
   <a
     className=""
     onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex="0"
   />
 </div>
 `;

--- a/benefit-finder/src/shared/components/Modal/index.jsx
+++ b/benefit-finder/src/shared/components/Modal/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 import NavModal from 'react-modal'
 import PropTypes from 'prop-types'
 import { ObfuscatedLink } from '../index'
@@ -65,6 +65,7 @@ const Modal = ({
 }) => {
   // state
   const [modalIsOpen, setIsOpen] = useState(false)
+  const triggerRef = useRef(null)
 
   // handlers
   /**
@@ -81,11 +82,15 @@ const Modal = ({
    * a function that triggers the modal to a closed state
    * @function
    */
-  const handleCloseModal = () => {
+  const handleCloseModal = triggerRef => {
+    // focus the trigger if it is still in the DOM
+    triggerRef && triggerRef.current.focus()
     // clear the hash
     window.location.hash = ''
     setIsOpen(false)
   }
+
+  const handleKeyValidation = e => e.which === 32 || e.which === 13
 
   // effects
   useEffect(() => {
@@ -100,9 +105,15 @@ const Modal = ({
    * @param {string} triggerLabel - passed to button for triggering modal
    * @return {html} returns an obfustacted anchor element
    */
-  const Trigger = ({ triggerLabel, onClick }) => {
+  const Trigger = ({ triggerLabel, onClick, onKeyDown }) => {
     return (
-      <ObfuscatedLink onClick={onClick} noCarrot>
+      <ObfuscatedLink
+        onClick={onClick}
+        onKeyDown={onKeyDown}
+        noCarrot
+        tabIndex="0"
+        triggerRef={triggerRef}
+      >
         {triggerLabel}
       </ObfuscatedLink>
     )
@@ -131,7 +142,9 @@ const Modal = ({
             id="navItemOneBtn"
             className="nav-item-one width-full"
             onClick={() => navItemOneFunction()}
+            onKeyDown={e => handleKeyValidation(e) && navItemOneFunction()}
             noCarrot
+            tabIndex="0"
           >
             {navItemOneLabel}
           </ObfuscatedLink>
@@ -141,7 +154,9 @@ const Modal = ({
             id="navItemTwoBtn"
             className="nav-item-two width-full"
             onClick={() => navItemTwoFunction()}
+            onKeyDown={e => handleKeyValidation(e) && navItemTwoFunction()}
             noCarrot
+            tabIndex="0"
           >
             {navItemTwoLabel}
           </ObfuscatedLink>
@@ -155,6 +170,7 @@ const Modal = ({
       <Trigger
         triggerLabel={triggerLabel}
         onClick={() => handleOpenModal()}
+        onKeyDown={e => handleKeyValidation(e) && handleOpenModal()}
       ></Trigger>
       <NavModal
         isOpen={modalIsOpen}
@@ -164,7 +180,7 @@ const Modal = ({
         <button
           type="button"
           className="modal-button"
-          onClick={() => handleCloseModal()}
+          onClick={() => handleCloseModal(triggerRef)}
         >
           <Close alt="a close out icon" />
         </button>

--- a/benefit-finder/src/shared/components/ObfuscatedLink/index.jsx
+++ b/benefit-finder/src/shared/components/ObfuscatedLink/index.jsx
@@ -23,6 +23,7 @@ const ObfuscatedLink = ({
   target,
   ext,
   noCarrot,
+  triggerRef,
   ...props
 }) => {
   // set our link as external, will be decorated by uswds css
@@ -38,6 +39,7 @@ const ObfuscatedLink = ({
       rel={rel}
       target={target}
       className={useHandleClassName({ className, defaultClasses })}
+      ref={triggerRef}
       {...props}
     >
       {children}

--- a/benefit-finder/src/shared/components/Radio/index.jsx
+++ b/benefit-finder/src/shared/components/Radio/index.jsx
@@ -42,6 +42,7 @@ const Radio = ({
           value={value || id}
           checked={checked}
           onChange={onChange}
+          id={id}
         />
         <Label className="usa-radio__label" htmlFor={id} label={label} />
       </div>

--- a/benefit-finder/src/shared/components/Radio/index.jsx
+++ b/benefit-finder/src/shared/components/Radio/index.jsx
@@ -23,6 +23,7 @@ const Radio = ({
   onChange,
   required,
   className,
+  name,
 }) => {
   const handleRequired = required === 'TRUE' ? ['required-field'] : ''
   const defaultClasses = ['usa-radio__input']
@@ -36,9 +37,8 @@ const Radio = ({
             defaultClasses,
             utilityClasses,
           })}
-          id={id}
           type="radio"
-          name={id}
+          name={name}
           value={value || id}
           checked={checked}
           onChange={onChange}

--- a/benefit-finder/src/shared/components/ResultsView/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/ResultsView/__tests__/__snapshots__/index.spec.js.snap
@@ -12,6 +12,7 @@ exports[`ResultsView renders a match to the previous snapshot 1`] = `
     >
       <h1
         className=""
+        id="skip-to-h1"
       >
         Your Custom List
       </h1>
@@ -39,6 +40,7 @@ exports[`ResultsView renders a match to the previous snapshot 1`] = `
       </button>
       <h3
         className=""
+        id=""
       >
         Results
       </h3>
@@ -69,6 +71,7 @@ exports[`ResultsView renders a match to the previous snapshot 1`] = `
       >
         <h3
           className=""
+          id=""
         >
           Benefits you did not qualify for
         </h3>
@@ -92,6 +95,7 @@ exports[`ResultsView renders a match to the previous snapshot 1`] = `
       >
         <h3
           className=""
+          id=""
         >
           Other benefits that might be relevant to you
         </h3>
@@ -111,6 +115,7 @@ exports[`ResultsView renders a match to the previous snapshot 1`] = `
                   >
                     <h3
                       className=""
+                      id=""
                     >
                       Approaching Retirement
                     </h3>
@@ -137,6 +142,7 @@ exports[`ResultsView renders a match to the previous snapshot 1`] = `
                   >
                     <h3
                       className=""
+                      id=""
                     >
                       Living with disability or illness
                     </h3>
@@ -157,6 +163,7 @@ exports[`ResultsView renders a match to the previous snapshot 1`] = `
       >
         <h3
           className=""
+          id=""
         >
           Sharing and printing
         </h3>

--- a/benefit-finder/src/shared/components/VerifySelectionsView/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/VerifySelectionsView/__tests__/__snapshots__/index.spec.js.snap
@@ -9,6 +9,7 @@ exports[`VerifySelectionsView renders a match to the previous snapshot 1`] = `
   >
     <h1
       className=""
+      id="skip-to-h1"
     />
     <div
       className="section-wrapper"


### PR DESCRIPTION
## PR Summary

This addresses the keyboard a11y issues identified in https://github.com/orgs/GSA/projects/48/views/16?filterQuery=sprint%3A%40current+assignee%3A%22scottqueen-bixal%22&pane=issue&itemId=38495201

## Related Github Issue

- fixes #508
- fixes #511 

## Detailed Testing steps

Link to testing steps in the issue or list them here:

- [x] you will need to have form data available in your local Drupal instance to test https://bears-waf.app.cloud.gov/sites/default/files/bears/api/life_event/death.json
- [x]  start the drupal server locally
- [x]  start the application locally

11 - “Continue” button skipped in keyboard order.
- [x] tab through the application
- [x] when you get to a navigation button, confirm that pressing `spacebar` initiates an action

12 - Modal window is  not keyboard accessible
- [x] when you get to the last section in the form, pressing `spacebar` should open the modal
- [x] confirm that you can navigate to the `close X` and the two other navigational buttons in the modal
- [x] confirm that you tabbing stays inside the modal
- [x] confirm that pressing spacebar on the `close X`  sets the focus back on the `trigger` continue button
- [x] confirm that pressing either of the navigational buttons inside the modal takes you to the expected view 

13 - “Skip to main content” not able to be activated with keyboard
- [x] this can not be tested until on sandbox, but we can confirm that each of the `<h1 />` elements has an id of `skip-to-h1` this is the id that usagov skip link looks for

16 - Radio buttons on forms are not correctly formatted and normal keyboard navigation is not expected.
- [ ] tab through until you get to a radio group
- [ ] when you tab into a radio group the first item should be focused
- [ ] when you tab again the next radio group first item should be focused
- [ ] when you arrow it should navigate through the options
- [ ] pressing space bar selects the item
- [ ] tabbing after selecting an item takes you to the next radio group where the first item should be focused

Additionally this fixes
https://github.com/orgs/GSA/projects/48/views/16?filterQuery=sprint%3A%40current+assignee%3A%22scottqueen-bixal%22&pane=issue&itemId=38496463

- [ ] activate ANDI  https://www.ssa.gov/accessibility/andi/help/install.html#install
- [ ] confirm that the label appears as "Yes" or "No" in context

example:

<img width="725" alt="Screenshot 2023-09-13 at 2 15 44 PM" src="https://github.com/GSA/px-bears-drupal/assets/37077057/016ffa93-c751-47e6-aaaf-2dd1abca7165">

