### PR TITLE
530 a11y step indicator

### DIFF
--- a/benefit-finder/src/App/index.jsx
+++ b/benefit-finder/src/App/index.jsx
@@ -41,6 +41,7 @@ function App({ appContent }) {
   // set data state
   const [stepDataArray, setStepDataArray] = useState()
   const [benfitsArray, setBenefitsArray] = useState()
+  const [modalOpen, setModalOpen] = useState(false)
 
   useEffect(() => {
     content && setBenefitsArray([...content.benefits])
@@ -104,13 +105,21 @@ function App({ appContent }) {
                   step={step}
                   setStep={setStep}
                   data={stepDataArray}
-                  handleData={() => setStepDataArray()}
+                  handleData={setStepDataArray}
                   stepData={stepData}
                   setStepData={setStepData}
                   verifyStep={verifyStep}
-                  setVerifyStep={() => setVerifyStep(true)}
-                  setViewResults={() => setViewResults(true)}
+                  setVerifyStep={() => {
+                    setVerifyStep(true)
+                    setModalOpen(false)
+                  }}
+                  setViewResults={() => {
+                    setViewResults(true)
+                    setModalOpen(false)
+                  }}
                   ui={t}
+                  modalOpen={modalOpen}
+                  setModalOpen={setModalOpen}
                 />
               </Form>
             </div>

--- a/benefit-finder/src/shared/api/mock-data/current.js
+++ b/benefit-finder/src/shared/api/mock-data/current.js
@@ -257,7 +257,7 @@ const content = `{
                 "fieldset": {
                   "criteriaKey": "deceased_date_of_death",
                   "legend": "Date of death",
-                  "required": "FALSE",
+                  "required": "TRUE",
                   "hint": "",
                   "inputs": [
                     {

--- a/benefit-finder/src/shared/api/mock-data/current.json
+++ b/benefit-finder/src/shared/api/mock-data/current.json
@@ -257,7 +257,7 @@
                 "fieldset": {
                   "criteriaKey": "deceased_date_of_death",
                   "legend": "Date of death",
-                  "required": "FALSE",
+                  "required": "TRUE",
                   "hint": "",
                   "inputs": [
                     {

--- a/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.js.snap
@@ -62,7 +62,6 @@ Array [
       </div>
       <div
         id="benefit-section"
-        onChange={[Function]}
       >
         <div
           className=""

--- a/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.js.snap
@@ -22,6 +22,7 @@ Array [
             className="usa-step-indicator__segments"
           >
             <li
+              aria-current={true}
               className="usa-step-indicator__segment usa-step-indicator__segment--current usa-step-indicator__segment--complete"
               onClick={[Function]}
             >
@@ -29,13 +30,10 @@ Array [
                 className="usa-step-indicator__segment-label"
               >
                 About the applicant
-                 
-                <span
-                  className="usa-sr-only"
-                />
               </span>
             </li>
             <li
+              aria-current={false}
               className="usa-step-indicator__segment usa-step-indicator__segment "
               onClick={[Function]}
             >
@@ -43,10 +41,6 @@ Array [
                 className="usa-step-indicator__segment-label"
               >
                 About the deceased
-                 
-                <span
-                  className="usa-sr-only"
-                />
               </span>
             </li>
           </ol>

--- a/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.js.snap
@@ -17,6 +17,7 @@ Array [
         <div
           aria-label="progress"
           className="usa-step-indicator"
+          tabIndex={0}
         >
           <ol
             className="usa-step-indicator__segments"
@@ -41,6 +42,11 @@ Array [
                 className="usa-step-indicator__segment-label"
               >
                 About the deceased
+                <span
+                  className="usa-sr-only"
+                >
+                  not-completed
+                </span>
               </span>
             </li>
           </ol>

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -90,6 +90,7 @@ const LifeEventSection = ({
       field.classList.remove('usa-input--error')
     })
     currentData.completed = true
+    console.log(currentData, currentData.completed)
     setValues([])
     return true
   }
@@ -230,7 +231,7 @@ const LifeEventSection = ({
               data={data}
               backLinkLabel={stepIndicator.stepBackLink}
               handleCheckRequriedFields={() => handleCheckRequriedFields()}
-              completed={currentData.section.completed}
+              completed={data}
               key={`step-indicator-${sectionHeadings}`}
             />
             {currentData && (

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -37,7 +37,10 @@ const LifeEventSection = ({
   setVerifyStep,
   setViewResults,
   ui,
+  modalOpen,
+  setModalOpen,
 }) => {
+  // const currentStep = step - 1
   // state
   const [modal, setModal] = useState(false)
   const [currentData, setCurrentData] = useState(() => data && data[step - 1])
@@ -51,6 +54,17 @@ const LifeEventSection = ({
     requiredLabel,
     sectionHeadings,
   } = ui
+
+  /**
+   * a function that updates our current data state
+   * @function
+   * @return {object} object as state
+   */
+  const handleUpdateData = () => {
+    data[step - 1] = { ...currentData }
+    handleData([...data])
+    // setCurrentData(currentData)
+  }
 
   /**
    *
@@ -90,7 +104,7 @@ const LifeEventSection = ({
       field.classList.remove('usa-input--error')
     })
     currentData.completed = true
-    console.log(currentData, currentData.completed)
+    handleUpdateData()
     setValues([])
     return true
   }
@@ -149,16 +163,6 @@ const LifeEventSection = ({
    */
   const handleBackUpdate = updateIndex => {
     setStep(step + updateIndex)
-  }
-
-  /**
-   * a function that updates our current data state
-   * @function
-   * @return {object} object as state
-   */
-  const handleUpdateData = () => {
-    handleData([...currentData])
-    setCurrentData(currentData)
   }
 
   /**
@@ -231,11 +235,10 @@ const LifeEventSection = ({
               data={data}
               backLinkLabel={stepIndicator.stepBackLink}
               handleCheckRequriedFields={() => handleCheckRequriedFields()}
-              completed={data}
               key={`step-indicator-${sectionHeadings}`}
             />
             {currentData && (
-              <div id="benefit-section" onChange={() => handleUpdateData}>
+              <div id="benefit-section">
                 <Alert
                   alertFieldRef={alertFieldRef}
                   heading={ui.alertBanner.heading}
@@ -461,6 +464,9 @@ const LifeEventSection = ({
                   navItemTwoFunction={setViewResults}
                   triggerLabel={buttonGroup[1].value}
                   handleCheckRequriedFields={handleCheckRequriedFields}
+                  modalOpen={modalOpen}
+                  setModalOpen={setModalOpen}
+                  completed={currentData.completed}
                 />
               </div>
             )}

--- a/benefit-finder/src/shared/components/Modal/index.jsx
+++ b/benefit-finder/src/shared/components/Modal/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import NavModal from 'react-modal'
 import PropTypes from 'prop-types'
 import { ObfuscatedLink } from '../index'
@@ -62,20 +62,33 @@ const Modal = ({
   navItemTwoLabel,
   navItemTwoFunction,
   handleCheckRequriedFields,
+  completed,
+  modalOpen,
+  setModalOpen,
 }) => {
   // state
-  const [modalIsOpen, setIsOpen] = useState(false)
   const triggerRef = useRef(null)
 
-  // handlers
   /**
    * a function that checks for errors and then triggers the modal to open state
    * @function
    */
+  // const handleOpenModal = useCallback(() => {
+  //   completed === true
+  //     ? setModalOpen(true)
+  //     : handleCheckRequriedFields() === true && setModalOpen
+  //   if (completed === true) {
+  //     setModalOpen(true)
+  //   }
+  // }, [completed, handleCheckRequriedFields, setModalOpen])
+
   const handleOpenModal = () => {
-    handleCheckRequriedFields
-      ? handleCheckRequriedFields() === true && setIsOpen(true)
-      : setIsOpen(true)
+    // completed === true
+    //   ? setModalOpen(true)
+    //   : handleCheckRequriedFields() === true && setModalOpen
+    if (handleCheckRequriedFields() === true) {
+      setModalOpen(true)
+    }
   }
 
   /**
@@ -87,7 +100,7 @@ const Modal = ({
     triggerRef && triggerRef.current.focus()
     // clear the hash
     window.location.hash = ''
-    setIsOpen(false)
+    setModalOpen(false)
   }
 
   const handleKeyValidation = e => e.which === 32 || e.which === 13
@@ -105,7 +118,7 @@ const Modal = ({
    * @param {string} triggerLabel - passed to button for triggering modal
    * @return {html} returns an obfustacted anchor element
    */
-  const Trigger = ({ triggerLabel, onClick, onKeyDown }) => {
+  const Trigger = ({ triggerLabel, onKeyDown, onClick }) => {
     return (
       <ObfuscatedLink
         onClick={onClick}
@@ -169,12 +182,12 @@ const Modal = ({
     <div id={id} className="benefit-modal-group">
       <Trigger
         triggerLabel={triggerLabel}
-        onClick={() => handleOpenModal()}
         onKeyDown={e => handleKeyValidation(e) && handleOpenModal()}
+        onClick={() => handleOpenModal()}
       ></Trigger>
       <NavModal
-        isOpen={modalIsOpen}
-        onRequestClose={handleCloseModal}
+        isOpen={modalOpen}
+        onRequestClose={() => handleCloseModal(triggerRef)}
         style={customStyles}
       >
         <button

--- a/benefit-finder/src/shared/components/StepIndicator/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/StepIndicator/__tests__/__snapshots__/index.spec.js.snap
@@ -5,6 +5,7 @@ exports[`StepIndicator renders a match to the previous snapshot 1`] = `
   <div
     aria-label="progress"
     className="usa-step-indicator"
+    tabIndex={0}
   >
     <ol
       className="usa-step-indicator__segments"

--- a/benefit-finder/src/shared/components/StepIndicator/index.jsx
+++ b/benefit-finder/src/shared/components/StepIndicator/index.jsx
@@ -21,7 +21,6 @@ const StepIndicator = ({
   setCurrent,
   backLinkLabel,
   handleCheckRequriedFields,
-  completed,
 }) => {
   /**
    * a functional component that supports a11y for completed steps
@@ -75,7 +74,7 @@ const StepIndicator = ({
           className="usa-step-indicator__segment-label"
         >
           {!noHeadings && heading}
-          {current === index ? null : (
+          {current === index && completed !== true ? null : (
             <CompletedSR
               key={`step-indicator-sr-${index}`}
               current={current}

--- a/benefit-finder/src/shared/components/StepIndicator/index.jsx
+++ b/benefit-finder/src/shared/components/StepIndicator/index.jsx
@@ -75,7 +75,7 @@ const StepIndicator = ({
           className="usa-step-indicator__segment-label"
         >
           {!noHeadings && heading}
-          {completed && (
+          {current === index ? null : (
             <CompletedSR
               key={`step-indicator-sr-${index}`}
               current={current}
@@ -89,7 +89,7 @@ const StepIndicator = ({
 
   return (
     <div>
-      <div className="usa-step-indicator" aria-label="progress">
+      <div className="usa-step-indicator" aria-label="progress" tabIndex={0}>
         <ol className="usa-step-indicator__segments">
           {data &&
             data.map((step, i) => {

--- a/benefit-finder/src/shared/components/StepIndicator/index.jsx
+++ b/benefit-finder/src/shared/components/StepIndicator/index.jsx
@@ -26,13 +26,17 @@ const StepIndicator = ({
   /**
    * a functional component that supports a11y for completed steps
    * @component
-   * @param {boolean} completed - assigns if the step has been completed
+   * @param {boolean} status - assigns if the step has been completed
    * @param {boolean} noHeadings - determinate to render headings or not
    * @return {html} returns markup for a usa step indicator
    */
-  const CompletedSR = ({ completed }) => (
-    <span className="usa-sr-only">{completed}</span>
-  )
+  const CompletedSR = ({ current, index }) => {
+    return (
+      <span className="usa-sr-only">
+        {current < index ? 'not-completed' : 'completed'}
+      </span>
+    )
+  }
 
   /**
    * a functional component that creates our step in the list
@@ -58,9 +62,9 @@ const StepIndicator = ({
         className={`usa-step-indicator__segment usa-step-indicator__segment${statusClass} ${
           current < index ? '' : 'usa-step-indicator__segment--complete'
         }`}
-        aria-current={completed}
+        aria-current={current === index}
         onClick={() =>
-          completed === false &&
+          completed !== true &&
           handleCheckRequriedFields() === true &&
           setCurrent(index + 1)
         }
@@ -70,8 +74,14 @@ const StepIndicator = ({
           key={`step-indicator-label-${index}`}
           className="usa-step-indicator__segment-label"
         >
-          {!noHeadings && heading}{' '}
-          <CompletedSR key={`step-indicator-sr-${index}`} status={completed} />
+          {!noHeadings && heading}
+          {completed && (
+            <CompletedSR
+              key={`step-indicator-sr-${index}`}
+              current={current}
+              index={index}
+            />
+          )}
         </span>
       </li>
     )
@@ -84,6 +94,8 @@ const StepIndicator = ({
           {data &&
             data.map((step, i) => {
               const heading = step.section.heading
+              const isCompleted = step.completed
+
               return (
                 <StepIndicatorSegment
                   heading={heading}
@@ -91,7 +103,7 @@ const StepIndicator = ({
                   index={i}
                   current={current}
                   setCurrent={setCurrent}
-                  completed={completed}
+                  completed={isCompleted}
                   handleCheckRequriedFields={handleCheckRequriedFields}
                 />
               )


### PR DESCRIPTION
## PR Summary

Fixes bug in component that allows current and not current aria elements to be present depending on the comparison of the current index

## Related Github Issue

- fixes #530

## Detailed Testing steps

Link to testing steps in the issue or list them here:

- [x] you will need to have form data available in your local Drupal instance to test https://bears-waf.app.cloud.gov/sites/default/files/bears/api/life_event/death.json
- [x]  start the drupal server locally
- [x]  start the application locally.
- [x] navigate to the first step in our form
- [x] inspect the elements of the step indicator
- [x] note that the current index does not have div with the class `usa-sr-only`
- [x] note that the second item has a sr only div with the content of `not-completed`
- [x] complete the required fields in the step and move to the next step of form
- [x] inspect the elements of the step indicator
- [x] note that the current index does not have div with the class `usa-sr-only`
- [x] note that the first item has an sr only div with the content of `completed`
