### PR TITLE
561 create cron to run deploy pipeline daily

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,19 +189,24 @@ jobs:
 workflows:
 # This workflow only gets triggered when there is a push to `main` branch.
   cms_build_and_deploy_workflow:
+    jobs:
+      - build_and_deploy:
+          filters:
+            branches:
+              only: 
+                - main
+
+  scheduled_cms_build_and_deploy_workflow:
     triggers:
       - schedule:
-          cron: '0 7 * * *'
+          cron: '* * * * *' #'0 7 * * *'
           filters:
             branches:
               only:
                 - 561-run-deploy-pipeline-on-cron
     jobs:
       - build_and_deploy:
-          filters:
-            branches:
-              only:
-                - 561-run-deploy-pipeline-on-cron
+
   create-component-library-workflow:
     jobs:
       - component-library:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,12 +189,15 @@ jobs:
 workflows:
 # This workflow only gets triggered when there is a push to `main` branch.
   cms_build_and_deploy_workflow:
-    jobs:
-      - build_and_deploy:
+    triggers:
+      - schedule:
+          cron: '*/10 * * * *'
           filters:
             branches:
-              only: 
-                - main
+              only:
+                - 561-run-deploy-pipeline-on-cron
+    jobs:
+      - build_and_deploy:
 
   create-component-library-workflow:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,6 +209,7 @@ workflows:
             branches:
               only:
                 - main
+                
 
 # deploy_waf_workflow gets only triggered when we manually enter 'manual_deploy' parameter and set it to true boolean value. 
   deploy_waf_workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ workflows:
               only:
                 - 561-run-deploy-pipeline-on-cron
     jobs:
-      - build_and_deploy:
+      - build_and_deploy
 
   create-component-library-workflow:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,7 +191,7 @@ workflows:
   cms_build_and_deploy_workflow:
     triggers:
       - schedule:
-          cron: '* * * * *'
+          cron: '0 7 * * *'
           filters:
             branches:
               only:
@@ -209,7 +209,7 @@ workflows:
             branches:
               only:
                 - main
-                
+
 
 # deploy_waf_workflow gets only triggered when we manually enter 'manual_deploy' parameter and set it to true boolean value. 
   deploy_waf_workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,7 +191,7 @@ workflows:
   cms_build_and_deploy_workflow:
     triggers:
       - schedule:
-          cron: '*/10 * * * *'
+          cron: '* * * * *'
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,11 +199,11 @@ workflows:
   scheduled_cms_build_and_deploy_workflow:
     triggers:
       - schedule:
-          cron: '* * * * *' #'0 7 * * *'
+          cron: '0 7 * * *'
           filters:
             branches:
               only:
-                - 561-run-deploy-pipeline-on-cron
+                - main
     jobs:
       - build_and_deploy
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,10 @@ workflows:
                 - 561-run-deploy-pipeline-on-cron
     jobs:
       - build_and_deploy:
-
+          filters:
+            branches:
+              only:
+                - 561-run-deploy-pipeline-on-cron
   create-component-library-workflow:
     jobs:
       - component-library:


### PR DESCRIPTION
## PR Summary

This PR creates an additional workflow that gets triggered daily and redeploys the app to cloud.gov. It makes sure that the additional steps get done to create and place `death.json` to make the `benefit-finder` up and running.

## Related Github Issue

- fixes #[Bug | App gets down after cloud.gov auto restaging#561](https://github.com/GSA/px-bears-drupal/issues/561)
