### PR TITLE
532 error handling date field

### DIFF
--- a/benefit-finder/src/shared/components/Date/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/Date/__tests__/__snapshots__/index.spec.js.snap
@@ -3,27 +3,28 @@
 exports[`Date renders a match to the previous snapshot 1`] = `
 <div
   className="usa-memorable-date"
+  id="usa-memorable-date-undefined"
 >
   <div
     className="usa-form-group usa-form-group--month usa-form-group--select"
   >
     <label
       className="usa-label"
-      htmlFor="date_of_birth_month"
+      htmlFor="date_of_birth_month-undefined"
     >
       Month
     </label>
     <div
       className="a11y-sr-only"
-      id="month-description"
+      id="month-description-undefined"
     >
       Select a month from the list
     </div>
     <select
-      aria-describedby="month-description"
+      aria-describedby="month-description-undefined"
       className="usa-select "
-      id="date_of_birth_month"
-      name="date_of_birth_month"
+      id="date_of_birth_month-undefined"
+      name="date_of_birth_month-undefined"
       required="required"
       value=""
     >
@@ -100,22 +101,22 @@ exports[`Date renders a match to the previous snapshot 1`] = `
   >
     <label
       className="usa-label"
-      htmlFor="date_of_birth_day"
+      htmlFor="date_of_birth_day-undefined"
     >
       Day
     </label>
     <div
       className="a11y-sr-only"
-      id="day-description"
+      id="day-description-undefined"
     >
       Enter numerals for day
     </div>
     <input
-      aria-describedby="day-description"
+      aria-describedby="day-description-undefined"
       className="usa-input "
-      id="date_of_birth_day"
+      id="date_of_birth_day-undefined"
       inputMode="numeric"
-      name="date_of_birth_day"
+      name="date_of_birth_day-undefined"
       value=""
     />
   </div>
@@ -124,22 +125,22 @@ exports[`Date renders a match to the previous snapshot 1`] = `
   >
     <label
       className="usa-label"
-      htmlFor="date_of_birth_year"
+      htmlFor="date_of_birth_year-undefined"
     >
       Year
     </label>
     <div
       className="a11y-sr-only"
-      id="year-description"
+      id="year-description-undefined"
     >
       Enter numerals for year
     </div>
     <input
-      aria-describedby="year-description"
+      aria-describedby="year-description-undefined"
       className="usa-input "
-      id="date_of_birth_year"
+      id="date_of_birth_year-undefined"
       inputMode="numeric"
-      name="date_of_birth_year"
+      name="date_of_birth_year-undefined"
       value=""
     />
   </div>

--- a/benefit-finder/src/shared/components/Date/_index.scss
+++ b/benefit-finder/src/shared/components/Date/_index.scss
@@ -2,6 +2,11 @@
 @use '../../styles/breakpoints/_index.scss' as *;
 
 #benefit-finder {
+  .date-alert {
+    display: block;
+    width: 100%;
+  }
+
   .usa-form-group {
     width: 100%;
   }

--- a/benefit-finder/src/shared/components/Date/index.jsx
+++ b/benefit-finder/src/shared/components/Date/index.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-// import parseDate from '../../utils/parseDate'
+import { Alert } from '../index'
 import './_index.scss'
 
 /**
@@ -10,29 +10,38 @@ import './_index.scss'
  * @param {object} value - inherited state values
  * @return {Date} returns a tandard format Date ie 1995-12-17T03:24:00
  */
-const Date = ({ onChange, value, required, ui }) => {
+const Date = ({ onChange, value, required, ui, id, valid }) => {
   const { date, select } = ui
-  const { labelDay, labelMonth, labelYear, monthOptions } = date
+  const { labelDay, labelMonth, labelYear, monthOptions, alert } = date
   const { dateDefaultValue } = select
 
   // Note: when we break each input into functional components they trigger unwanted rerenders
 
   return (
-    <div className="usa-memorable-date">
+    <div id={`usa-memorable-date-${id}`} className="usa-memorable-date">
+      {valid === true && (
+        <Alert
+          className="date-alert"
+          heading={ui.alertBanner.heading}
+          description={alert}
+          error
+        ></Alert>
+      )}
       <div className="usa-form-group usa-form-group--month usa-form-group--select">
-        <label className="usa-label" htmlFor="date_of_birth_month">
+        <label className="usa-label" htmlFor={`date_of_birth_month-${id}`}>
           {labelMonth}
         </label>
-        <div id="month-description" className="a11y-sr-only">
+        <div id={`month-description-${id}`} className="a11y-sr-only">
           Select a month from the list
         </div>
         <select
           className={`usa-select ${
             required === 'TRUE' ? 'required-field' : ''
           }`}
-          id="date_of_birth_month"
-          name="date_of_birth_month"
-          aria-describedby="month-description"
+          // ref={monthFieldRef}
+          id={`date_of_birth_month-${id}`}
+          name={`date_of_birth_month-${id}`}
+          aria-describedby={`month-description-${id}`}
           required="required"
           value={(value && value.month) || ''}
           onChange={onChange}
@@ -48,37 +57,39 @@ const Date = ({ onChange, value, required, ui }) => {
         </select>
       </div>
       <div className="usa-form-group usa-form-group--day">
-        <label className="usa-label" htmlFor="date_of_birth_day">
+        <label className="usa-label" htmlFor={`date_of_birth_day-${id}`}>
           {labelDay}
         </label>
-        <div id="day-description" className="a11y-sr-only">
+        <div id={`day-description-${id}`} className="a11y-sr-only">
           Enter numerals for day
         </div>
         <input
           className={`usa-input ${required === 'TRUE' ? 'required-field' : ''}`}
-          aria-describedby="day-description"
-          id="date_of_birth_day"
-          name="date_of_birth_day"
+          aria-describedby={`day-description-${id}`}
+          id={`date_of_birth_day-${id}`}
+          name={`date_of_birth_day-${id}`}
           inputMode="numeric"
           value={(value && value.day) || ''}
           onChange={onChange}
+          // ref={dayFieldRef}
         />
       </div>
       <div className="usa-form-group usa-form-group--year">
-        <label className="usa-label" htmlFor="date_of_birth_year">
+        <label className="usa-label" htmlFor={`date_of_birth_year-${id}`}>
           {labelYear}
         </label>
-        <div id="year-description" className="a11y-sr-only">
+        <div id={`year-description-${id}`} className="a11y-sr-only">
           Enter numerals for year
         </div>
         <input
           className={`usa-input ${required === 'TRUE' ? 'required-field' : ''}`}
-          aria-describedby="year-description"
-          id="date_of_birth_year"
-          name="date_of_birth_year"
+          aria-describedby={`year-description-${id}`}
+          id={`date_of_birth_year-${id}`}
+          name={`date_of_birth_year-${id}`}
           inputMode="numeric"
           value={(value && value.year) || ''}
           onChange={onChange}
+          // ref={yearFieldRef}
         />
       </div>
     </div>

--- a/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/LifeEventSection/__tests__/__snapshots__/index.spec.js.snap
@@ -113,27 +113,28 @@ Array [
           <div>
             <div
               className="usa-memorable-date"
+              id="usa-memorable-date-applicant_date_of_birth_0"
             >
               <div
                 className="usa-form-group usa-form-group--month usa-form-group--select"
               >
                 <label
                   className="usa-label"
-                  htmlFor="date_of_birth_month"
+                  htmlFor="date_of_birth_month-applicant_date_of_birth_0"
                 >
                   Month
                 </label>
                 <div
                   className="a11y-sr-only"
-                  id="month-description"
+                  id="month-description-applicant_date_of_birth_0"
                 >
                   Select a month from the list
                 </div>
                 <select
-                  aria-describedby="month-description"
+                  aria-describedby="month-description-applicant_date_of_birth_0"
                   className="usa-select required-field"
-                  id="date_of_birth_month"
-                  name="date_of_birth_month"
+                  id="date_of_birth_month-applicant_date_of_birth_0"
+                  name="date_of_birth_month-applicant_date_of_birth_0"
                   onChange={[Function]}
                   required="required"
                   value=""
@@ -211,22 +212,22 @@ Array [
               >
                 <label
                   className="usa-label"
-                  htmlFor="date_of_birth_day"
+                  htmlFor="date_of_birth_day-applicant_date_of_birth_0"
                 >
                   Day
                 </label>
                 <div
                   className="a11y-sr-only"
-                  id="day-description"
+                  id="day-description-applicant_date_of_birth_0"
                 >
                   Enter numerals for day
                 </div>
                 <input
-                  aria-describedby="day-description"
+                  aria-describedby="day-description-applicant_date_of_birth_0"
                   className="usa-input required-field"
-                  id="date_of_birth_day"
+                  id="date_of_birth_day-applicant_date_of_birth_0"
                   inputMode="numeric"
-                  name="date_of_birth_day"
+                  name="date_of_birth_day-applicant_date_of_birth_0"
                   onChange={[Function]}
                   value=""
                 />
@@ -236,22 +237,22 @@ Array [
               >
                 <label
                   className="usa-label"
-                  htmlFor="date_of_birth_year"
+                  htmlFor="date_of_birth_year-applicant_date_of_birth_0"
                 >
                   Year
                 </label>
                 <div
                   className="a11y-sr-only"
-                  id="year-description"
+                  id="year-description-applicant_date_of_birth_0"
                 >
                   Enter numerals for year
                 </div>
                 <input
-                  aria-describedby="year-description"
+                  aria-describedby="year-description-applicant_date_of_birth_0"
                   className="usa-input required-field"
-                  id="date_of_birth_year"
+                  id="date_of_birth_year-applicant_date_of_birth_0"
                   inputMode="numeric"
-                  name="date_of_birth_year"
+                  name="date_of_birth_year-applicant_date_of_birth_0"
                   onChange={[Function]}
                   value=""
                 />

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -69,28 +69,6 @@ const LifeEventSection = ({
 
   const handleFieldAlerts = () => {
     setHasError(document.querySelectorAll(`.${classError}`))
-    console.log(hasError)
-    // hasError.forEach(error => console.log(error.id))
-    // ✅ You can read or write refs in event handlers
-    // console.log(
-    //   'month',
-    //   monthFieldRef.current.className,
-    //   monthFieldRef.current.classList.contains(classError)
-    // )
-    // if (monthFieldRef.current.classList.contains(classError)) {
-    //   return setAlertBanner(true)
-    // } else {
-    //   return setAlertBanner(false)
-    // }
-    // const childGroupElements = Array.from(dateRef.current.children)
-    // const childInputElements = childGroupElements.map(child => child.children)
-    // // console.log(childInputElements)
-    // childInputElements.forEach(child => console.log(child[2]))
-    // if (monthFieldRef.current.classList.contains(classError)) {
-    //   return setAlertBanner(true)
-    // } else {
-    //   return setAlertBanner(false)
-    // }
   }
 
   /**
@@ -216,7 +194,6 @@ const LifeEventSection = ({
    * @return {object} object as state
    */
   const handleDateChanged = (event, criteriaKey) => {
-    handleFieldAlerts()
     window.history.replaceState({}, '', window.location.pathname)
     dateInputValidation(event) === true &&
       apiCalls.PUT.DataDate(

--- a/benefit-finder/src/shared/components/LifeEventSection/index.jsx
+++ b/benefit-finder/src/shared/components/LifeEventSection/index.jsx
@@ -45,6 +45,8 @@ const LifeEventSection = ({
   const [modal, setModal] = useState(false)
   const [currentData, setCurrentData] = useState(() => data && data[step - 1])
   const [values, setValues] = useState([])
+  const [hasError, setHasError] = useState([])
+  const classError = 'usa-input--error'
 
   // desctructure data
   const {
@@ -63,7 +65,32 @@ const LifeEventSection = ({
   const handleUpdateData = () => {
     data[step - 1] = { ...currentData }
     handleData([...data])
-    // setCurrentData(currentData)
+  }
+
+  const handleFieldAlerts = () => {
+    setHasError(document.querySelectorAll(`.${classError}`))
+    console.log(hasError)
+    // hasError.forEach(error => console.log(error.id))
+    // ✅ You can read or write refs in event handlers
+    // console.log(
+    //   'month',
+    //   monthFieldRef.current.className,
+    //   monthFieldRef.current.classList.contains(classError)
+    // )
+    // if (monthFieldRef.current.classList.contains(classError)) {
+    //   return setAlertBanner(true)
+    // } else {
+    //   return setAlertBanner(false)
+    // }
+    // const childGroupElements = Array.from(dateRef.current.children)
+    // const childInputElements = childGroupElements.map(child => child.children)
+    // // console.log(childInputElements)
+    // childInputElements.forEach(child => console.log(child[2]))
+    // if (monthFieldRef.current.classList.contains(classError)) {
+    //   return setAlertBanner(true)
+    // } else {
+    //   return setAlertBanner(false)
+    // }
   }
 
   /**
@@ -85,8 +112,9 @@ const LifeEventSection = ({
     // add to all the collected error fields an error class
     values.forEach(field => {
       field.classList.contains('required-field') &&
-        field.classList.add('usa-input--error')
+        field.classList.add(classError)
     })
+    handleFieldAlerts()
     currentData.completed = false
     window.scrollTo(0, 0)
     return false
@@ -101,7 +129,7 @@ const LifeEventSection = ({
     alertFieldRef.current.classList.add('display-none')
     // remove from all the collected error fields the error class
     values.forEach(field => {
-      field.classList.remove('usa-input--error')
+      field.classList.remove(classError)
     })
     currentData.completed = true
     handleUpdateData()
@@ -188,6 +216,7 @@ const LifeEventSection = ({
    * @return {object} object as state
    */
   const handleDateChanged = (event, criteriaKey) => {
+    handleFieldAlerts()
     window.history.replaceState({}, '', window.location.pathname)
     dateInputValidation(event) === true &&
       apiCalls.PUT.DataDate(
@@ -205,6 +234,10 @@ const LifeEventSection = ({
       ? 'FALSE'
       : item.fieldset.required
   }
+
+  // useEffect(() => {
+  //   handleFieldAlerts()
+  // }, [])
 
   // manage the display of our modal initializer
   useEffect(() => {
@@ -395,6 +428,13 @@ const LifeEventSection = ({
                                     )
                                   }
                                   ui={ui}
+                                  id={fieldSetId}
+                                  valid={
+                                    hasError.length &&
+                                    Array.from(hasError)
+                                      .map(item => item.id.includes(fieldSetId))
+                                      .includes(true)
+                                  }
                                 />
                               </div>
                             )

--- a/benefit-finder/src/shared/locales/en/en.json
+++ b/benefit-finder/src/shared/locales/en/en.json
@@ -137,6 +137,7 @@
     "dateDefaultValue": "-Select-"
   },
   "date": {
+    "alert": "Date should follow the format 01 - January 22 1977",
     "labelDay": "Day",
     "labelMonth": "Month",
     "labelYear": "Year",

--- a/benefit-finder/src/shared/locales/es/es.json
+++ b/benefit-finder/src/shared/locales/es/es.json
@@ -137,6 +137,7 @@
     "dateDefaultValue": "-Seleccionar-"
   },
   "date": {
+    "alert": "La fecha debe seguir el formato 01 - 22 de enero de 1977.",
     "labelDay": "Día",
     "labelMonth": "Mes",
     "labelYear": "Año",


### PR DESCRIPTION
## PR Summary

This includes functionality to provide an alert banner in line with the date group if there is an error.

## Related Github Issue

- fixes #532 

## Detailed Testing steps

Link to testing steps in the issue or list them here:

- [x] navigate to the first step
- [x] in the first date input field update to 10 - October 1 9
- [x] click `continue`
- [x] confirm error alerts show at top of form step

<img width="1168" alt="Screenshot 2023-09-28 at 12 48 44 PM" src="https://github.com/GSA/px-bears-drupal/assets/37077057/7bb002a1-deb7-4588-99fc-e986283ecef6">

- [ ] confirm error alerts show above date input form group
- [ ] update year to 2022
- [ ] click `continue`
- [ ] confirm navigation to next step
- [ ] click `back`
- [ ] confirm that input state is retained and no alert is displayed
