### PR TITLE
570 debug year input

### DIFF
--- a/benefit-finder/src/shared/utils/inputValidation.js
+++ b/benefit-finder/src/shared/utils/inputValidation.js
@@ -13,7 +13,7 @@ export const dateInputValidation = event => {
       if (event.target.value.length === 4) {
         // 1900 - currentyear
         const range = new RegExp(
-          `^(19[0-9][0-9]|200[0-9]|20[0-2][0-${yearLimit}])$`
+          `^(19[0-9][0-9]|20[0-1][0-9]|20[0-2][0-${yearLimit}])$`
         )
         return range.test(`${event.target.value}`)
       }


### PR DESCRIPTION
## PR Summary

This resolves a bug where users were unable to input some combinations of valid numbers.  ie. `201[0-9]`. Our expected range is between `1900-current year`.

## Related Github Issue

- fixes GSA/px-benefit-finder#144 

## Detailed Testing steps

Link to testing steps in the issue or list them here:

- [x] navigate to first date input field within the form
- [x] confirm you can enter any eligible number between `1900-current year`
