### PR TITLE
569 resolve accordion error

### DIFF
--- a/benefit-finder/src/shared/components/Accordion/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/Accordion/__tests__/__snapshots__/index.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Accordion renders a match to the previous snapshot 1`] = `
 <div
-  className="benefit-accordion"
+  className="benefit-accordion usa-accordion"
 >
   <h4
     className="usa-accordion__heading"

--- a/benefit-finder/src/shared/components/Accordion/index.jsx
+++ b/benefit-finder/src/shared/components/Accordion/index.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import accordion from '@uswds/uswds/js/usa-accordion'
 import PropTypes from 'prop-types'
 import './_index.scss'
 
@@ -21,6 +22,14 @@ const Accordion = ({
   hidden,
   ...props
 }) => {
+  useEffect(() => {
+    accordion.on()
+
+    // remove event listeners when the component un-mounts.
+    return () => {
+      accordion.off()
+    }
+  })
   /**
    * a hook that hanldes our open state of the accordion
    * @function
@@ -66,8 +75,7 @@ const Accordion = ({
     !isOpen ? <Open alt="a plus icon" /> : <Close alt="a minus icon" />
 
   return (
-    <div className="benefit-accordion" {...props} hidden={hidden}>
-      {/* we don't use `usa-accordion` class because it is too opinionated about control, this throws an error from the uswds javascript, but does not impact/break functionality */}
+    <div className="benefit-accordion usa-accordion" {...props} hidden={hidden}>
       <h4 className="usa-accordion__heading">
         <button
           type="button"
@@ -85,7 +93,7 @@ const Accordion = ({
       <div
         id={id}
         className="usa-accordion__content usa-prose"
-        hidden={!isOpen}
+        hidden={isOpen || true}
       >
         <div>{children}</div>
       </div>


### PR DESCRIPTION
## PR Summary

this pulls in uswds js to instantiate the accordion so that the uncaught error can be resolved in dev error boundaries.

## Related Github Issue

- fixes #569 

## Detailed Testing steps

- [x] navigate form, fill any required fields
- [x] click accordion
- [x] ensure error is no longer present
