### PR TITLE
Handle JSON data miss criteria

### DIFF
--- a/usagov_bears/modules/usagov_bears_api/src/Controller/LifeEventController.php
+++ b/usagov_bears/modules/usagov_bears_api/src/Controller/LifeEventController.php
@@ -352,17 +352,20 @@ class LifeEventController {
       $benefit_eligibility = [];
 
       $criteria = current($eligibility->get('field_b_criteria_key')->referencedEntities());
-      $ckey = $criteria->get('field_b_criteria_key')->value;
+      if ($criteria) {
+        $ckey = $criteria->get('field_b_criteria_key')->value;
 
-      $benefit_eligibility['criteriaKey'] = $ckey;
-      $benefit_eligibility['label'] = $eligibility->get('field_b_label')->value ?? "";
+        $benefit_eligibility['criteriaKey'] = $ckey;
+        $benefit_eligibility['label'] = $eligibility->get('field_b_label')->value ?? "";
 
-      $acceptableValues = $eligibility->get('field_b_acceptable_values')->getValue();
-      foreach ($acceptableValues as $key => $acceptableValue) {
-        $benefit_eligibility['acceptableValues'][] = $acceptableValue['value'];
+        $acceptableValues = $eligibility->get('field_b_acceptable_values')->getValue();
+        foreach ($acceptableValues as $key => $acceptableValue) {
+          $benefit_eligibility['acceptableValues'][] = $acceptableValue['value'];
+        }
+
+        $benefit_eligibilitys[] = $benefit_eligibility;
       }
 
-      $benefit_eligibilitys[] = $benefit_eligibility;
     }
 
     $benefit['eligibility'] = $benefit_eligibilitys;

--- a/usagov_bears/modules/usagov_bears_content/usagov_bears_content.module
+++ b/usagov_bears/modules/usagov_bears_content/usagov_bears_content.module
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @file
+ * Module contains functions related to usagov_bears_content.
+ */
+
+/**
+ * Implements hook_form_alter().
+ */
+function usagov_bears_content_form_alter(&$form, &$form_state, $form_id) {
+  if ($form_id == "node_bears_benefit_edit_form") {
+    $i = 0;
+    do {
+      $ckey_widget = $form['field_b_eligibility']['widget'][$i]['subform']['field_b_criteria_key']['widget'];
+      if (empty($ckey_widget)) {
+        break;
+      }
+      $type = $ckey_widget['#type'];
+      $required = $ckey_widget['#required'];
+      if ($type == "select" && $required == 1) {
+        $form['field_b_eligibility']['widget'][$i]['subform']['field_b_criteria_key']['widget']['#options'] =
+          array('_none' => '- None -') +
+          $form['field_b_eligibility']['widget'][$i]['subform']['field_b_criteria_key']['widget']['#options'];
+      }
+      $i++;
+    } while ($i > 0);
+  }
+}


### PR DESCRIPTION
## PR Summary

This work resolves the issue of JSON data building failure with missing eligibility criteria in benefit content.
The JSON data includes benefits for the given life event. 
The benefit content includes many eligibility criteria.
The JSON data building failed when benefit eligibility criteria missing, for example content editor deleted.

Implement solution:
[1] Do not build the missing eligibility criteria.
[2] In benefit edit form, add None option for required select widget of eligibility criteria. This will prevent content editor to select the first option in select widget of missing criteria by accident.

