### PR TITLE
460 add menu to life event

### DIFF
--- a/usagov_bears/modules/usagov_bears_content/config/optional/node.type.bears_life_event.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/node.type.bears_life_event.yml
@@ -7,19 +7,20 @@ dependencies:
 third_party_settings:
   menu_ui:
     available_menus:
-      - main
-    parent: 'main:'
+      - left-menu-english
+      - left-menu-spanish
+    parent: 'left-menu-english:'
   node_menus:
-    enabled: 0
+    enabled: 1
     languages:
       en:
         available_menus:
-          - main
-        parent: 'main:'
+          - left-menu-english
+        parent: 'left-menu-english:'
       es:
         available_menus:
-          - main
-        parent: 'main:'
+          - left-menu-spanish
+        parent: 'left-menu-spanish:'
 name: 'Bears Life Event'
 type: bears_life_event
 description: 'Bears Life Event'


### PR DESCRIPTION
## PR Summary

This work adds left-menu-english and left-menu-spanish to content type life event.
This enables to build mobile menu and breadcrumb for Benefit Finder app.

## Related Github Issue

- fixes #460 

## Detailed Testing steps

To test in sandbox

Navigate to Benefit Finder tool in relative URL
/bears/life_event/death

review breadcrumb
![image](https://github.com/GSA/px-bears-drupal/assets/88853916/fa4c9a23-9d81-4602-9a30-0f6c52d30cff)

review mobile menu
![image](https://github.com/GSA/px-bears-drupal/assets/88853916/6dd0d615-4b13-4cc8-af9b-a503662d53f9)
