### PR TITLE
602 content UI audit updates

### DIFF
--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/index.spec.js
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/__tests__/index.spec.js
@@ -1,9 +1,12 @@
 import renderer from 'react-test-renderer'
 import BenefitAccordionGroup from '../index.jsx'
+import * as en from '../../../locales/en/en.json'
 
 describe('BenefitAccordionGroup', () => {
   it('renders a match to the previous snapshot', () => {
-    const component = renderer.create(<BenefitAccordionGroup />)
+    const component = renderer.create(
+      <BenefitAccordionGroup ui={en.resultsView} />
+    )
     expect(component.toJSON()).toMatchSnapshot()
   })
 })

--- a/benefit-finder/src/shared/components/BenefitAccordionGroup/index.jsx
+++ b/benefit-finder/src/shared/components/BenefitAccordionGroup/index.jsx
@@ -24,7 +24,17 @@ const BenefitAccordionGroup = ({
   entryKey,
   expandAll,
   notQualifiedView,
+  ui,
 }) => {
+  const { benefitAccordion, benefitAccordionGroup } = ui
+  const {
+    eligibleStatusLabels,
+    agencyPrefix,
+    visitLabel,
+    unmetLabel,
+    additionalDescription,
+  } = benefitAccordion
+  const { closedState, openState } = benefitAccordionGroup
   /**
    * a hook that hanldes our open state of the accordions in our group
    * @function
@@ -38,7 +48,7 @@ const BenefitAccordionGroup = ({
    * @function
    * @return {stroing} returns label for our button
    */
-  const handleExpandIcon = isExpandAll ? 'Collapse all -' : 'Expand all +'
+  const handleExpandIcon = isExpandAll ? `${openState} -` : `${closedState} +`
 
   /**
    * a functional component that renders a button and controls the expansion of our accordions
@@ -69,7 +79,7 @@ const BenefitAccordionGroup = ({
   const NotEligibleList = ({ items }) => {
     return (
       <div className="unmet-criteria-group">
-        <div className="unmet-criteria-title">UNMET CRITERIA</div>
+        <div className="unmet-criteria-title">{unmetLabel}</div>
         <ul className="unmet-criteria-list">
           {items.map((item, index) => {
             const { label } = item
@@ -96,7 +106,7 @@ const BenefitAccordionGroup = ({
   const MoreInfoList = ({ items }) => {
     return (
       <div className="unmet-criteria-group">
-        <div className="unmet-criteria-title">MORE INFORMATION NEEDED</div>
+        <div className="unmet-criteria-title">{eligibleStatusLabels[1]}</div>
         <ul className="unmet-criteria-list">
           {items.map((item, index) => {
             const { label } = item
@@ -143,11 +153,11 @@ const BenefitAccordionGroup = ({
           // z > 0	"Not Eligible"
           const eligibleStatus =
             eligibleBenefits.length === eligibility.length
-              ? 'Likely Eligible'
+              ? eligibleStatusLabels[0]
               : notEligibleBenefits.length === 0 &&
                 moreInformationNeeded.length > 0
-              ? 'More Information Needed'
-              : 'Not Eligible'
+              ? eligibleStatusLabels[1]
+              : eligibleStatusLabels[2]
 
           const handleHidden =
             notQualifiedView === false && eligibleStatus !== 'Likely Eligible'
@@ -170,7 +180,7 @@ const BenefitAccordionGroup = ({
               hidden={handleHidden}
             >
               <Heading className="benefit-detail-title" headingLevel={4}>
-                {`Provided by ${agency.title}`}
+                {`${agencyPrefix} ${agency.title}`}
               </Heading>
               <div
                 className="benefit-detail-summary"
@@ -180,6 +190,7 @@ const BenefitAccordionGroup = ({
                 className="benefit-criteria-list"
                 data={eligibleBenefits}
                 initialEligibilityLength={eligibility.length}
+                ui={benefitAccordion}
               />
               {notEligibleBenefits.length > 0 && (
                 <NotEligibleList items={notEligibleBenefits} />
@@ -187,17 +198,14 @@ const BenefitAccordionGroup = ({
               {moreInformationNeeded.length > 0 && (
                 <MoreInfoList items={moreInformationNeeded} />
               )}
-              <Alert className="benefit-alert">
-                Additional eligibility criteria may apply. Please visit agency
-                for full requirements.
-              </Alert>
+              <Alert className="benefit-alert">{additionalDescription}</Alert>
               <ObfuscatedLink
                 className="benefit-link"
                 href={SourceLink}
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Visit {agency.title}
+                {visitLabel} {agency.title}
               </ObfuscatedLink>
             </Accordion>
           )

--- a/benefit-finder/src/shared/components/Intro/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/Intro/__tests__/__snapshots__/index.spec.js.snap
@@ -110,7 +110,7 @@ exports[`Intro renders a match to the previous snapshot 1`] = `
                     <div
                       dangerouslySetInnerHTML={
                         Object {
-                          "__html": "<div>Your information<strong> will not</strong> be shared, saved, or submitted.</div>",
+                          "__html": "<div>Your information<strong> is not</strong> shared, saved, or submitted.</div>",
                         }
                       }
                     />
@@ -134,7 +134,7 @@ exports[`Intro renders a match to the previous snapshot 1`] = `
                     <div
                       dangerouslySetInnerHTML={
                         Object {
-                          "__html": "Provide complete and accurate information to get the most relevant results.",
+                          "__html": "Provide complete info to get more relevant results.",
                         }
                       }
                     />

--- a/benefit-finder/src/shared/components/KeyElegibilityCrieriaList/__tests__/index.spec.js
+++ b/benefit-finder/src/shared/components/KeyElegibilityCrieriaList/__tests__/index.spec.js
@@ -1,9 +1,12 @@
 import renderer from 'react-test-renderer'
 import KeyElegibilityCrieriaList from '../index.jsx'
+import * as en from '../../../locales/en/en.json'
 
 describe('KeyElegibilityCrieriaList', () => {
   it('renders a match to the previous snapshot', () => {
-    const component = renderer.create(<KeyElegibilityCrieriaList />)
+    const component = renderer.create(
+      <KeyElegibilityCrieriaList ui={en.resultsView.benefitAccordion} />
+    )
     expect(component.toJSON()).toMatchSnapshot()
   })
 })

--- a/benefit-finder/src/shared/components/KeyElegibilityCrieriaList/index.jsx
+++ b/benefit-finder/src/shared/components/KeyElegibilityCrieriaList/index.jsx
@@ -15,7 +15,9 @@ const KeyElegibilityCrieriaList = ({
   className,
   data,
   initialEligibilityLength,
+  ui,
 }) => {
+  const { benefitSummary, benefitSummaryConjunction } = ui
   const defaultClasses = ['key-eligibility-criteria-group']
 
   return (
@@ -27,7 +29,7 @@ const KeyElegibilityCrieriaList = ({
             className="key-eligibility-criteria-heading"
             headingLevel={5}
           >
-            {`Key Eligibility Criteria Meet ${data.length} of
+            {`${benefitSummary} ${data.length} ${benefitSummaryConjunction}
             ${initialEligibilityLength}`}
           </Heading>
           <ul className="key-eligibility-criteria-list">

--- a/benefit-finder/src/shared/components/NoticesList/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/NoticesList/__tests__/__snapshots__/index.spec.js.snap
@@ -23,7 +23,7 @@ exports[`NoticesList renders a match to the previous snapshot 1`] = `
             <div
               dangerouslySetInnerHTML={
                 Object {
-                  "__html": "<div>Your information<strong> will not</strong> be shared, saved, or submitted.</div>",
+                  "__html": "<div>Your information<strong> is not</strong> shared, saved, or submitted.</div>",
                 }
               }
             />
@@ -47,7 +47,7 @@ exports[`NoticesList renders a match to the previous snapshot 1`] = `
             <div
               dangerouslySetInnerHTML={
                 Object {
-                  "__html": "Provide complete and accurate information to get the most relevant results.",
+                  "__html": "Provide complete info to get more relevant results.",
                 }
               }
             />

--- a/benefit-finder/src/shared/components/ResultsView/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/shared/components/ResultsView/__tests__/__snapshots__/index.spec.js.snap
@@ -14,12 +14,12 @@ exports[`ResultsView renders a match to the previous snapshot 1`] = `
         className=""
         id="skip-to-h1"
       >
-        Your Custom List
+        Your potential benefits
       </h1>
       <div
         dangerouslySetInnerHTML={
           Object {
-            "__html": "<div><p><strong>Here is your list of potential Federal Benefits.</strong> Your state, city or employer may offer other benefits. Visit each agency providing the benefit to learn if you are truly eligible and conduct an actual application.</p></div>",
+            "__html": "<div><p>Visit each agency to find true eligibility and to apply. Check with your city, state, or employer for other benefits.</p></div>",
           }
         }
       />
@@ -47,7 +47,7 @@ exports[`ResultsView renders a match to the previous snapshot 1`] = `
       <p
         dangerouslySetInnerHTML={
           Object {
-            "__html": "<div><strong>Based on your answers you meet the criteria to qualify for these benefits:</strong></div>",
+            "__html": "<div><strong>You may be eligible for these benefits:</strong></div>",
           }
         }
       />
@@ -62,7 +62,7 @@ exports[`ResultsView renders a match to the previous snapshot 1`] = `
             onClick={[Function]}
             type="button"
           >
-            Expand all +
+            Open all +
           </button>
         </div>
       </div>
@@ -97,7 +97,7 @@ exports[`ResultsView renders a match to the previous snapshot 1`] = `
           className=""
           id=""
         >
-          Other benefits that might be relevant to you
+          More benefits
         </h3>
         <ul
           className="add-list-reset"
@@ -165,7 +165,7 @@ exports[`ResultsView renders a match to the previous snapshot 1`] = `
           className=""
           id=""
         >
-          Sharing and printing
+          Share results
         </h3>
         <div
           className="result-view-share-results-button-group"
@@ -186,7 +186,7 @@ exports[`ResultsView renders a match to the previous snapshot 1`] = `
           </button>
         </div>
         <p>
-          Copy a link to this page with the criteria you selected above. Make sure to share it only with those you trust as your answers will be visible.
+          Copy or email these results. Your answers will be visible. Only share with those you trust.
         </p>
       </div>
     </div>

--- a/benefit-finder/src/shared/components/ResultsView/index.jsx
+++ b/benefit-finder/src/shared/components/ResultsView/index.jsx
@@ -98,6 +98,7 @@ const ResultsView = ({ handleStepBack, ui, data, stepDataArray }) => {
               entryKey={'benefit'}
               notQualifiedView={notQualifiedView}
               expandAll
+              ui={ui}
             />
           </div>
           {notQualifiedView === false && (

--- a/benefit-finder/src/shared/components/ResultsView/index.jsx
+++ b/benefit-finder/src/shared/components/ResultsView/index.jsx
@@ -139,7 +139,7 @@ const ResultsView = ({ handleStepBack, ui, data, stepDataArray }) => {
             <Heading headingLevel={3}>{shareResults?.heading}</Heading>
             <div className="result-view-share-results-button-group">
               <ShareButton
-                ui={shareResults?.shareButton}
+                ui={shareResults}
                 data={
                   stepDataArray && apiCalls.GET.SelectedValueAll(stepDataArray)
                 }

--- a/benefit-finder/src/shared/components/ShareButton/index.jsx
+++ b/benefit-finder/src/shared/components/ShareButton/index.jsx
@@ -23,14 +23,14 @@ const ShareButton = ({ ui, data }) => {
   const handleClick = () => {
     setShareLink(buildURIParameter(window.location.href, data))
     navigator.clipboard.writeText(shareLink).then(
-      () => alert(`copied successfully! ${shareLink}`),
+      () => alert(`${ui?.shareLinkContent} ${shareLink}`),
       err => alert('Failed to copy', err)
     )
   }
 
   return (
     <Button secondary onClick={handleClick}>
-      {ui || 'Share'}
+      {ui?.shareButton || 'Share'}
     </Button>
   )
 }

--- a/benefit-finder/src/shared/locales/en/en.json
+++ b/benefit-finder/src/shared/locales/en/en.json
@@ -122,6 +122,7 @@
     "shareResults": {
       "heading": "Share results",
       "shareButton": "Share link",
+      "shareLinkContent": "Copied",
       "emailButton": "Email results",
       "emailSubject": "Results from USAGov’s benefit finder",
       "description": "Copy or email these results. Your answers will be visible. Only share with those you trust."

--- a/benefit-finder/src/shared/locales/en/en.json
+++ b/benefit-finder/src/shared/locales/en/en.json
@@ -19,10 +19,10 @@
       "heading": "Before you start:",
       "list": [
         {
-          "notice": "<div>Your information<strong> will not</strong> be shared, saved, or submitted.</div>"
+          "notice": "<div>Your information<strong> is not</strong> shared, saved, or submitted.</div>"
         },
         {
-          "notice": "Provide complete and accurate information to get the most relevant results."
+          "notice": "Provide complete info to get more relevant results."
         },
         {
           "notice": "<div><strong>This form is not an application.</strong> You will need to apply for benefits with each agency.</div>"
@@ -62,6 +62,7 @@
   },
   "verifySelectionsView": {
     "heading": "Review and Confirm",
+    "noResultsLabel": "No input given",
     "buttonGroup": [
       {
         "value": "Back"
@@ -74,24 +75,41 @@
   "resultsView": {
     "qualified": {
       "chevron": {
-        "heading": "Your Custom List",
-        "description": "<div><p><strong>Here is your list of potential Federal Benefits.</strong> Your state, city or employer may offer other benefits. Visit each agency providing the benefit to learn if you are truly eligible and conduct an actual application.</p></div>"
+        "heading": "Your potential benefits",
+        "description": "<div><p>Visit each agency to find true eligibility and to apply. Check with your city, state, or employer for other benefits.</p></div>"
       },
       "heading": "Results",
-      "description": "<div><strong>Based on your answers you meet the criteria to qualify for these benefits:</strong></div>"
+      "description": "<div><strong>You may be eligible for these benefits:</strong></div>"
     },
     "notQualified": {
       "chevron": {
-        "heading": "Benefits You Did Not Qualify For",
-        "description": ""
+        "heading": "Benefits you did not qualify for",
+        "description": "According to your answers you are not eligible for these benefits."
       },
       "heading": "Results",
-      "description": "<div><strong>Based on your answers you did not meet the criteria to qualify for these benefits:</strong></div>"
+      "description": "<div><strong>Based on your answers you are not eligible for these benefits.</strong>You may become eligible if you enter additional information or your situation changes.</div>"
     },
     "stepBackLink": "Back",
     "eligibleResults": {
       "heading": "Results",
       "description": "You may be eligible for these benefits."
+    },
+    "benefitAccordionGroup": {
+      "closedState": "Open all",
+      "openState": "Close all"
+    },
+    "benefitAccordion": {
+      "eligibleStatusLabels": [
+        "Likely Eligible",
+        "More Information Needed",
+        "Not Eligible"
+      ],
+      "agencyPrefix": "By",
+      "benefitSummary": "Key eligibility criteria Met",
+      "benefitSummaryConjunction": "of",
+      "unmetLabel": "Unmet criteria",
+      "additionalDescription": "Additional eligibility criteria may apply. Visit the link below for more information and to apply.",
+      "visitLabel": "Visit"
     },
     "notEligibleResults": {
       "heading": "Benefits you did not qualify for",
@@ -99,14 +117,14 @@
       "cta": "See benefits you did not qualify for"
     },
     "relativeBenefits": {
-      "heading": "Other benefits that might be relevant to you"
+      "heading": "More benefits"
     },
     "shareResults": {
-      "heading": "Sharing and printing",
+      "heading": "Share results",
       "shareButton": "Share link",
       "emailButton": "Email results",
       "emailSubject": "Results from USAGov’s benefit finder",
-      "description": "Copy a link to this page with the criteria you selected above. Make sure to share it only with those you trust as your answers will be visible."
+      "description": "Copy or email these results. Your answers will be visible. Only share with those you trust."
     }
   },
   "shareResults": {
@@ -120,10 +138,6 @@
         "value": "Email results"
       }
     ]
-  },
-  "benefitAccordionGroup": {
-    "closedState": "Open all",
-    "openState": "Close all"
   },
   "sectionHeadings": {
     "start": "Complete Questions",

--- a/benefit-finder/src/shared/locales/es/es.json
+++ b/benefit-finder/src/shared/locales/es/es.json
@@ -22,10 +22,10 @@
           "notice": "<div>Su información <strong>no será</strong> compartida, guardada o presentada.</div>"
         },
         {
-          "notice": "Ingrese la información más completa para obtener una lista más relevante de resultados."
+          "notice": "Ingrese la información completa para obtener resultados más relevantes."
         },
         {
-          "notice": "<div><strong>Este formulario no es una aplicación.</strong> Tendrá que presentar una solicitud por cada beneficio.</div>"
+          "notice": "<div><strong>Este formulario no es una aplicación.</strong> Tiene que presentar una solicitud por cada beneficio.</div>"
         }
       ]
     },
@@ -43,7 +43,7 @@
   },
   "buttonGroup": [
     {
-      "value": "Volver atrás"
+      "value": "Volver"
     },
     {
       "value": "Continuar"
@@ -62,6 +62,7 @@
   },
   "verifySelectionsView": {
     "heading": "Revisar y confirmar",
+    "noResultsLabel": "No se ha dado ninguna entrada",
     "buttonGroup": [
       {
         "value": "Volver"
@@ -75,23 +76,40 @@
     "qualified": {
       "chevron": {
         "heading": "Sus beneficios potenciales",
-        "description": "<div><p>Necesita verificar los requisitos y visitar la página de cada agencia para aplicar.<strong> Para conocer otros beneficios, consulte a su ciudad, estado, o trabajo.</strong></p></div>"
+        "description": "<div><p>Visite la página de cada agencia para verificar los requisitos y aplicar. Para conocer otros beneficios, consulte a su ciudad, estado, o trabajo.</p></div>"
       },
       "heading": "Resultados",
-      "description": "<div><strong>Usted puede calificar para los siguientes beneficios:<strong/></div>"
+      "description": "<div><strong>Podría calificar para estos beneficios:<strong/></div>"
     },
     "notQualified": {
       "chevron": {
-        "heading": "Beneficios a los cuales no calificó",
-        "description": ""
+        "heading": "Beneficios a los que no calificó",
+        "description": "Según sus respuestas usted no es elegible para estos beneficios."
       },
       "heading": "Resultados",
-      "description": "<div><strong>De acuerdo a sus respuestas usted no cumple con los requisitos para acceder a estos beneficios:<strong/></div>"
+      "description": "<div><strong>Según sus respuestas no es elegible para estos beneficios.<strong/> Podría calificar si tiene información adicional o si su situación cambia.</div>"
     },
     "stepBackLink": "Volver",
     "eligibleResults": {
       "heading": "Resultados",
       "description": "Podría calificar para estos beneficios:"
+    },
+    "benefitAccordionGroup": {
+      "closedState": "Abrir todos",
+      "openState": "Cerrar todos"
+    },
+    "benefitAccordion": {
+      "eligibleStatusLabels": [
+        "Likely Eligible",
+        "Más información requerida",
+        "Not Eligible"
+      ],
+      "agencyPrefix": "",
+      "benefitSummary": "Criterios de elegibilidad Cumple",
+      "benefitSummaryConjunction": "de",
+      "unmetLabel": "No cumplió con",
+      "additionalDescription": "Puede haber requisitos adicionales. Visite el enlace abajo para más información y para aplicar.",
+      "visitLabel": "Visita"
     },
     "notEligibleResults": {
       "heading": "Beneficios a los que no calificó",
@@ -99,14 +117,14 @@
       "cta": "Vea los beneficios a los que no calificó"
     },
     "relativeBenefits": {
-      "heading": "Sugerencias"
+      "heading": "Más beneficios"
     },
     "shareResults": {
-      "heading": "Imprimir y Compartir",
+      "heading": "Imprima y comparta",
       "shareButton": "Compartir resultados",
       "emailButton": "Enviar resultados",
       "emailSubject": "Resultados del buscador de beneficios de USAGov",
-      "description": "Copie un enlace a esta página con los criterios que seleccionó anteriormente. Asegúrate de compartirlo solo con aquellos en los que confías, ya que tus respuestas serán visibles."
+      "description": "Copie o envíe sus resultados por correo. Sus respuestas serán visibles. Solo comparta con quienes confíe."
     }
   },
   "shareResults": {
@@ -120,10 +138,6 @@
         "value": "Enviar resultados"
       }
     ]
-  },
-  "benefitAccordionGroup": {
-    "closedState": "Abrir todos",
-    "openState": "Cerrar todos"
   },
   "sectionHeadings": {
     "start": "Preguntas completas",

--- a/benefit-finder/src/shared/locales/es/es.json
+++ b/benefit-finder/src/shared/locales/es/es.json
@@ -123,6 +123,7 @@
       "heading": "Imprima y comparta",
       "shareButton": "Compartir resultados",
       "emailButton": "Enviar resultados",
+      "shareLinkContent": "Copiado",
       "emailSubject": "Resultados del buscador de beneficios de USAGov",
       "description": "Copie o envíe sus resultados por correo. Sus respuestas serán visibles. Solo comparta con quienes confíe."
     }


### PR DESCRIPTION
## PR Summary

This works tu update content and translations for the UI.  

## Related Github Issue

- fixes #602 

## Detailed Testing steps

This document has all the UI based content marked with a light grey background.
https://docs.google.com/document/d/1wt3hIA6vd6XuiS5XCkY5YhMLxysawxu-lnTvAytt2VA/edit

ie.
<img width="690" alt="Screenshot 2023-10-09 at 12 57 46 PM" src="https://github.com/GSA/px-bears-drupal/assets/37077057/6171999c-123f-4eb6-9651-d6005c4c2845">

- [ ] navigate application in es, ensure no en content remains
- [ ] navigate application in en, ensure no es content remains
- [ ] compare document values to locale values, enure vales match as expected

*Exception: the related benefits section is being developed here ->  https://github.com/GSA/px-bears-drupal/pull/573

