### PR TITLE
618 add draft json data program in pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
             echo "$CR_PAT" | docker login ghcr.io --username "$GH_USERNAME" --password-stdin
             CF_DOCKER_PASSWORD=$( echo $CR_PAT) cf push cms  --docker-image "$DOCKERREPO:$IMAGE_TAG" --docker-username "$CF_USER"
             docker logout
-            sleep 30
+            sleep 20
 
       - run:
           name: Enable benefit-finder module
@@ -209,7 +209,7 @@ workflows:
           filters:
             branches:
               only: 
-                - main
+                - 618-add-draft-json-data-program-in-pipeline
 
   scheduled_cms_build_and_deploy_workflow:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,10 @@ jobs:
                                   curl http://127.0.0.1:8080/bears/api/life-event/retirement/jsonfile && \
                                   curl http://127.0.0.1:8080/bears/api/life-event/es_retirement/jsonfile && \
                                   curl http://127.0.0.1:8080/bears/api/life-event/disability/jsonfile && \
-                                  curl http://127.0.0.1:8080/bears/api/life-event/es_disability/jsonfile && \
+                                  curl http://127.0.0.1:8080/bears/api/life-event/es_disability/jsonfile && \           
+                                  curl http://127.0.0.1:8080/bears/api/life-event/death/jsonfile?mode=draft  && \
+                                  curl http://127.0.0.1:8080/bears/api/life-event/retirement/jsonfile?mode=draft  && \
+                                  curl http://127.0.0.1:8080/bears/api/life-event/disability/jsonfile?mode=draft  && \
                                   ls -l && \
                                   /var/www/vendor/bin/drush cr"
 
@@ -204,7 +207,7 @@ workflows:
           filters:
             branches:
               only: 
-                - main
+                - 618-add-draft-json-data-program-in-pipeline
 
   scheduled_cms_build_and_deploy_workflow:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
             echo "$CR_PAT" | docker login ghcr.io --username "$GH_USERNAME" --password-stdin
             CF_DOCKER_PASSWORD=$( echo $CR_PAT) cf push cms  --docker-image "$DOCKERREPO:$IMAGE_TAG" --docker-username "$CF_USER"
             docker logout
-            sleep 20
+            sleep 30
 
       - run:
           name: Enable benefit-finder module

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,9 +117,6 @@ jobs:
                                   ls -l && \
                                   /var/www/vendor/bin/drush cr"
 
-
-
-  
   component-library:
     machine:
       image: ubuntu-2004:202107-02
@@ -209,7 +206,7 @@ workflows:
           filters:
             branches:
               only: 
-                - 618-add-draft-json-data-program-in-pipeline
+                - main
 
   scheduled_cms_build_and_deploy_workflow:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,12 +106,14 @@ jobs:
                                   curl http://127.0.0.1:8080/bears/api/life-event/death/jsonfile && \
                                   curl http://127.0.0.1:8080/bears/api/life-event/es_death/jsonfile && \
                                   curl http://127.0.0.1:8080/bears/api/life-event/retirement/jsonfile && \
-                                  curl http://127.0.0.1:8080/bears/api/life-event/es_retirement/jsonfile && \
                                   curl http://127.0.0.1:8080/bears/api/life-event/disability/jsonfile && \
                                   curl http://127.0.0.1:8080/bears/api/life-event/es_disability/jsonfile && \           
                                   curl http://127.0.0.1:8080/bears/api/life-event/death/jsonfile?mode=draft  && \
                                   curl http://127.0.0.1:8080/bears/api/life-event/retirement/jsonfile?mode=draft  && \
                                   curl http://127.0.0.1:8080/bears/api/life-event/disability/jsonfile?mode=draft  && \
+                                  curl http://127.0.0.1:8080/bears/api/life-event/es_retirement/jsonfile?mode=draft && \
+                                  curl http://127.0.0.1:8080/bears/api/life-event/es_death/jsonfile?mode=draft && \
+                                  curl http://127.0.0.1:8080/bears/api/life-event/es_disability/jsonfile?mode=draft && \ 
                                   ls -l && \
                                   /var/www/vendor/bin/drush cr"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,7 @@ workflows:
           filters:
             branches:
               only: 
-                - 618-add-draft-json-data-program-in-pipeline
+                - main
 
   scheduled_cms_build_and_deploy_workflow:
     triggers:


### PR DESCRIPTION
## PR Summary

This PR configures the pipeline to generate the below draft JSON files:

- /sites/default/files/bears/api/draft/life_event/es_death.json
- /sites/default/files/bears/api/draft/life_event/es_retirement.json
- /sites/default/files/bears/api/draft/life_event/es_disability.json
- /sites/default/files/bears/api/draft/life_event/death.json
- /sites/default/files/bears/api/draft/life_event/retirement.json
- /sites/default/files/bears/api/draft/life_event/disability.json


## Related Github Issue

- fixes #618 [Add draft JSON data program in pipeline#618](https://github.com/GSA/px-bears-drupal/issues/618)


