### PR TITLE
609 update fetch for draft mode

### DIFF
--- a/benefit-finder/src/shared/api/apiCalls.js
+++ b/benefit-finder/src/shared/api/apiCalls.js
@@ -165,16 +165,19 @@ export const Language = () => {
  * @return {JSON} returns JSON data if succesfull
  */
 export async function LifeEvent(lifeEvent) {
-  let language
+  let language, params, mode
   // get life-event from location
   if (lifeEvent === undefined) {
     const string = /^\/es/
     language = string.test(window.location.pathname) ? 'es_' : ''
+    const windowQuery = window.location.search
+    params = new URLSearchParams(windowQuery)
+    mode = params.get('mode') ? `${params.get('mode')}/` : ''
     const location = window.location.pathname
     lifeEvent = location.substring(location.lastIndexOf('/') + 1)
   }
   const response = await fetch(
-    `/sites/default/files/bears/api/life_event/${language}${lifeEvent}.json`
+    `/sites/default/files/bears/api/${mode}life_event/${language}${lifeEvent}.json`
   )
     .then(response => {
       if (response?.ok) {

--- a/benefit-finder/src/shared/api/apiCalls.js
+++ b/benefit-finder/src/shared/api/apiCalls.js
@@ -172,7 +172,7 @@ export async function LifeEvent(lifeEvent) {
     language = string.test(window.location.pathname) ? 'es_' : ''
     const windowQuery = window.location.search
     params = new URLSearchParams(windowQuery)
-    mode = params.get('mode') ? `${params.get('mode')}/` : ''
+    mode = params.get('mode') === 'draft' ? `${params.get('mode')}/` : ''
     const location = window.location.pathname
     lifeEvent = location.substring(location.lastIndexOf('/') + 1)
   }


### PR DESCRIPTION
## PR Summary

This updates our fetch logic to handle  `mode=draft` parameter

## Related Github Issue

- fixes #609 

## Detailed Testing steps

- [ ] proxy urls for latest data from sandbox
- [ ] pass `mode=draft` parameter
- [ ] ensure the network 200 response from `draft` directory
- [ ] test with Spanish


https://github.com/GSA/px-bears-drupal/assets/37077057/8e2e3fb1-b915-47d7-b201-b26a51a0328b




