### PR TITLE
654 json data file field in life event

### DIFF
--- a/usagov_bears/modules/usagov_bears_app/usagov_bears_page/templates/page--bears-life-event.html.twig
+++ b/usagov_bears/modules/usagov_bears_app/usagov_bears_page/templates/page--bears-life-event.html.twig
@@ -119,7 +119,7 @@
   <div class="grid-container">
     {{ page.breadcrumb }}
   </div>
-  <div id="benefit-finder" json_data_file_path="{{ json_data_file_path }}" draft_json_data_file_path="{{ draft_json_data_file_path }}"></div>
+  <div id="benefit-finder" json-data-file-path="{{ json_data_file_path }}" draft-json-data-file-path="{{ draft_json_data_file_path }}"></div>
 
   {% else %}
   <main class="main-content usa-layout-docs no-footer-gap {{ main_classes }}" role="main" id="main-content" data-pagetype="{{term_name}}">

--- a/usagov_bears/modules/usagov_bears_app/usagov_bears_page/templates/page--bears-life-event.html.twig
+++ b/usagov_bears/modules/usagov_bears_app/usagov_bears_page/templates/page--bears-life-event.html.twig
@@ -119,7 +119,7 @@
   <div class="grid-container">
     {{ page.breadcrumb }}
   </div>
-  <div id="benefit-finder"></div>
+  <div id="benefit-finder" json_data_file_path="{{ json_data_file_path }}" draft_json_data_file_path="{{ draft_json_data_file_path }}"></div>
 
   {% else %}
   <main class="main-content usa-layout-docs no-footer-gap {{ main_classes }}" role="main" id="main-content" data-pagetype="{{term_name}}">

--- a/usagov_bears/modules/usagov_bears_app/usagov_bears_page/usagov_bears_page.module
+++ b/usagov_bears/modules/usagov_bears_app/usagov_bears_page/usagov_bears_page.module
@@ -58,6 +58,9 @@ function usagov_bears_page_preprocess_page(&$variables) {
       $field_json_data_file = $node->get('field_json_data_file')->referencedEntities();
       $uri = $field_json_data_file[0]->getFileUri();
       $variables['json_data_file_path'] = \Drupal::service('file_url_generator')->generate($uri)->toString();
+      $field_draft_json_data_file = $node->get('field_draft_json_data_file')->referencedEntities();
+      $uri = $field_draft_json_data_file[0]->getFileUri();
+      $variables['draft_json_data_file_path'] = \Drupal::service('file_url_generator')->generate($uri)->toString();
     }
   }
 }

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.node.bears_life_event.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_form_display.node.bears_life_event.default.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - field.field.node.bears_life_event.field_b_id
+    - field.field.node.bears_life_event.field_draft_json_data_file
     - field.field.node.bears_life_event.field_json_data_file
     - field.field.node.bears_life_event.field_language_toggle
     - field.field.node.bears_life_event.field_summary
@@ -29,6 +30,13 @@ content:
     settings:
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  field_draft_json_data_file:
+    type: file_generic
+    weight: 26
+    region: content
+    settings:
+      progress_indicator: throbber
     third_party_settings: {  }
   field_json_data_file:
     type: file_generic
@@ -102,6 +110,11 @@ content:
     settings:
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  translation:
+    weight: 10
+    region: content
+    settings: {  }
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_life_event.default.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_life_event.default.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - field.field.node.bears_life_event.field_b_id
+    - field.field.node.bears_life_event.field_draft_json_data_file
     - field.field.node.bears_life_event.field_json_data_file
     - field.field.node.bears_life_event.field_language_toggle
     - field.field.node.bears_life_event.field_summary
@@ -22,6 +23,14 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 3
+    region: content
+  field_draft_json_data_file:
+    type: file_default
+    label: above
+    settings:
+      use_description_as_link_text: true
+    third_party_settings: {  }
+    weight: 6
     region: content
   field_json_data_file:
     type: file_default

--- a/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_life_event.teaser.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/core.entity_view_display.node.bears_life_event.teaser.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.bears_life_event.field_b_id
+    - field.field.node.bears_life_event.field_draft_json_data_file
     - field.field.node.bears_life_event.field_json_data_file
     - field.field.node.bears_life_event.field_language_toggle
     - field.field.node.bears_life_event.field_summary
@@ -22,6 +23,7 @@ content:
     region: content
 hidden:
   field_b_id: true
+  field_draft_json_data_file: true
   field_json_data_file: true
   field_language_toggle: true
   field_summary: true

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_life_event.field_draft_json_data_file.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.field.node.bears_life_event.field_draft_json_data_file.yml
@@ -2,18 +2,18 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.field_json_data_file
+    - field.storage.node.field_draft_json_data_file
     - node.type.bears_life_event
   module:
     - file
-id: node.bears_life_event.field_json_data_file
-field_name: field_json_data_file
+id: node.bears_life_event.field_draft_json_data_file
+field_name: field_draft_json_data_file
 entity_type: node
 bundle: bears_life_event
-label: 'JSON data file'
+label: 'Draft Json data file'
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_draft_json_data_file.yml
+++ b/usagov_bears/modules/usagov_bears_content/config/optional/field.storage.node.field_draft_json_data_file.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - file
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_draft_json_data_file
+field_name: field_draft_json_data_file
+entity_type: node
+type: file
+settings:
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+module: file
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
## PR Summary

This work add and use json data file field in life event for integration with React and TOME static build.

- add draft json data file field in life event
- assign json data file to json data file field when generating json data file
- add attribute json-data-file-path and draft-json-data-file-path in template for React

## Related Github Issue

- fixes #654 

## Detailed Testing steps

To test in sandbox or local environment

Navigate to url to generate json data file
http://localhost/bears/api/life-event/death/jsonfile

Navigate to url to generate draft json data file
http://localhost/bears/api/life-event/death/jsonfile?mode=draft

Edit life event to see the json data file field.
![image](https://github.com/GSA/px-bears-drupal/assets/88853916/fba0c34d-ac89-438b-94ac-6ce8bbc9c533)

Navigate to Benefit Finder app to see the data attribute
http://localhost/bears/life_event/death
![image](https://github.com/GSA/px-bears-drupal/assets/88853916/7e291ff1-0efa-4584-982b-bf653350e87f)




