### PR TITLE
[669] - remove code to enable bears module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,11 +91,6 @@ jobs:
             cf login -a https://api.fr.cloud.gov -u "$CF_USER" -p "$CF_PASSWORD" -o "$CF_ORG"  -s "$CF_SPACE"
             cf ssh cms --command "/var/www/vendor/bin/drush state:set system.maintenance_mode 0 && \
                                   /var/www/vendor/bin/drush pm:uninstall usagov_login && \
-                                  /var/www/vendor/bin/drush pm:enable usagov_bears_block && \
-                                  /var/www/vendor/bin/drush pm:enable usagov_bears_content && \
-                                  /var/www/vendor/bin/drush pm:enable usagov_bears_api && \
-                                  /var/www/vendor/bin/drush pm:enable usagov_bears && \
-                                  /var/www/vendor/bin/drush pm:enable usagov_bears_page && \
                                   /var/www/vendor/bin/drush cr && \
                                   cd ../var/www/web/sites/default/files && \
                                   mkdir -p bears/api/life_event && \


### PR DESCRIPTION
## PR Summary

This PR removes the code in the pipeline to enable bears module as instructed by the senior dev per below:
![image](https://github.com/GSA/px-bears-drupal/assets/81575505/1ddf0ac8-8bc1-4a17-ae5c-e378b4c70fdb)


## Related Github Issue

- fixes #669 
