### PR TITLE
Replace BEARS with BENEFIT FINDER

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
             bash ./mv-benefit-finder-app.sh
             echo ".................."
             echo "moving the benefit-finder-app module into the usagov-2021 directory"
-            mv usagov_bears usagov-2021/web/modules/custom
+            mv usagov_benefit_finder usagov-2021/web/modules/custom
             mv html.html.twig usagov-2021/web/themes/custom/usagov/templates/html.html.twig
 
       - run: 

--- a/mv-benefit-finder-app.sh
+++ b/mv-benefit-finder-app.sh
@@ -15,15 +15,15 @@ readonly BENEFIT_FINDER_MEDIA_DIRECTORY_NAME="/media"
 readonly BENEFIT_FINDER_MEDIA_DIRECTORY="${BENEFIT_FINDER_STATIC_FILE_LOCATION}${BENEFIT_FINDER_MEDIA_DIRECTORY_NAME}"
 
 # BENEFIT_FINDER_MODULE
-readonly BENEFIT_FINDER_MODULE_LIBRARY_LOCATION="${SCRIPT_DIR}/usagov_bears/modules/usagov_bears_app/usagov_bears_page"
+readonly BENEFIT_FINDER_MODULE_LIBRARY_LOCATION="${SCRIPT_DIR}/usagov_benefit_finder/modules/usagov_benefit_finder_app/usagov_benefit_finder_page"
 readonly BENEFIT_FINDER_MODULE_JS_FILE_LOCATION="${BENEFIT_FINDER_MODULE_LIBRARY_LOCATION}/js"
 readonly BENEFIT_FINDER_MODULE_CSS_FILE_LOCATION="${BENEFIT_FINDER_MODULE_LIBRARY_LOCATION}/css"
 readonly BENEFIT_FINDER_MODULE_MEDIA_DIRECTORY_LOCATION="${BENEFIT_FINDER_MODULE_LIBRARY_LOCATION}/media"
 
-# check if bears application exist
+# check if benefit-finder application exist
 if test -d "$BENEFIT_FINDER_LOCATION"; then
     echo "\xE2\x9C\x94 App directory exists"
-    # build bears_app
+    # build benefit_finder_app
     cd "${BENEFIT_FINDER_LOCATION}"
     echo -e "Building BENEFIT_FINDER app..."
     npm ci
@@ -35,7 +35,7 @@ if test -f "$BENEFIT_FINDER_JS_FILE"; then
     echo "\xE2\x9C\x94 App build file exist"
     echo "\xE2\x9C\x94 Build successfull"
 
-    # check if bears custom module library directory exist
+    # check if benefit-finder custom module library directory exist
     if test -d "$BENEFIT_FINDER_MODULE_JS_FILE_LOCATION"; then
         echo "\xE2\x9C\x94 Custom module directory exists"
         # move build file

--- a/mv-usagov_benefit_finder.sh
+++ b/mv-usagov_benefit_finder.sh
@@ -3,9 +3,9 @@
 # get current directory
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-# BEARS_MODULE
-BEARS_MODULE="usagov_bears"
-readonly BEARS_MODULE_LOCATION="${SCRIPT_DIR}/${BEARS_MODULE}"
+# BENEFIT_FINDER_MODULE
+BENEFIT_FINDER_MODULE="usagov_benefit_finder"
+readonly BENEFIT_FINDER_MODULE_LOCATION="${SCRIPT_DIR}/${BENEFIT_FINDER_MODULE}"
 
 # USAGOV-2021 project
 readonly USAGOV_PROJECT_LOCATION="${SCRIPT_DIR}/usagov-2021"
@@ -24,10 +24,10 @@ else
 fi
 
 # check if module directory exist
-if test -d "$BEARS_MODULE_LOCATION"
+if test -d "$BENEFIT_FINDER_MODULE_LOCATION"
 then
-    echo "\xE2\x9C\x94 usa.gov bears module exist"
-    echo "Moving BEARS custom module to usa.gov project..."
-    cp -r $BEARS_MODULE_LOCATION $USAGOV_PROJECT_CUSTOM_MODULES_LOCATION
-    test -f "${USAGOV_PROJECT_CUSTOM_MODULES_LOCATION}${BEARS_MODULE}"; echo -e "\xE2\x9C\x94 BEARS Module successfully moved"
+    echo "\xE2\x9C\x94 usa.gov benefit-finder module exist"
+    echo "Moving BENEFIT_FINDER custom module to usa.gov project..."
+    cp -r $BENEFIT_FINDER_MODULE_LOCATION $USAGOV_PROJECT_CUSTOM_MODULES_LOCATION
+    test -f "${USAGOV_PROJECT_CUSTOM_MODULES_LOCATION}${BENEFIT_FINDER_MODULE}"; echo -e "\xE2\x9C\x94 BENEFIT_FINDER Module successfully moved"
 fi


### PR DESCRIPTION
## PR Summary

This PR replaces `bears` with `benefit_finder` in mv-usagov_benefit_finder.sh script. It also updates the module name in the pipeline file.

## Related Github Issue

- fixes #669 
