### PR TITLE
684 Benefit Finder module configuration page

### DIFF
--- a/usagov_benefit_finder/config/install/usagov_benefit_finder.settings.yml
+++ b/usagov_benefit_finder/config/install/usagov_benefit_finder.settings.yml
@@ -1,0 +1,1 @@
+automate_json_data_file_generating: false

--- a/usagov_benefit_finder/src/Form/BenefitFinderSettingsForm.php
+++ b/usagov_benefit_finder/src/Form/BenefitFinderSettingsForm.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\usagov_benefit_finder\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+class BenefitFinderSettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'usagov_benefit_finder_admin_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildForm($form, $form_state);
+
+    $form['automate_json_data_file_generating'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Automate JSON data file generating'),
+      '#description' => $this->t("If checked, automate JSON data file generating when Benefit Finder content changes."),
+      '#return_value' => TRUE,
+      '#default_value' => $this->config('usagov_benefit_finder.settings')
+        ->get('automate_json_data_file_generating'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->config('usagov_benefit_finder.settings')
+      ->set('automate_json_data_file_generating', $form_state->getValue('automate_json_data_file_generating'))
+      ->save();
+
+    return parent::submitForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'usagov_benefit_finder.settings',
+    ];
+  }
+
+}

--- a/usagov_benefit_finder/usagov_benefit_finder.links.menu.yml
+++ b/usagov_benefit_finder/usagov_benefit_finder.links.menu.yml
@@ -1,0 +1,13 @@
+usagov_benefit_finder.admin:
+  title: 'Benefit Finder'
+  parent: system.admin_config
+  route_name: usagov_benefit_finder.main
+  description: 'Benefit Finder'
+  weight: 150
+
+usagov_benefit_finder.settings:
+  title: 'Benefit Finder configuration'
+  parent: usagov_benefit_finder.admin
+  route_name: usagov_benefit_finder.settings
+  description: 'Configure Benefit Finder.'
+  weight: 150

--- a/usagov_benefit_finder/usagov_benefit_finder.routing.yml
+++ b/usagov_benefit_finder/usagov_benefit_finder.routing.yml
@@ -1,0 +1,17 @@
+usagov_benefit_finder.main:
+  path: '/admin/config/usagov_benefit_finder/main'
+  defaults:
+    _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
+    _title: 'USAGov Benefit Finder Tools'
+  requirements:
+    _permission: 'administer site configuration'
+
+usagov_benefit_finder.settings:
+  path: '/admin/config/development/usagov_benefit_finder'
+  defaults:
+    _title: 'Benefit Finder Settings'
+    _form: '\Drupal\usagov_benefit_finder\Form\BenefitFinderSettingsForm'
+  requirements:
+    _permission: 'administer site configuration'
+  options:
+    _admin_route: TRUE


### PR DESCRIPTION
## PR Summary

This work creates Benefit Finder module configuration page form.

## Related Github Issue

- fixes #684 

## Detailed Testing steps

To test in sandbox or local: 

Navigate to http://localhost/admin/config
![image](https://github.com/GSA/px-bears-drupal/assets/88853916/704efa7b-cf54-4e01-91d0-40b0f69a3394)

Click "Benefit Finder Configuration" link.
http://localhost/admin/config/usagov_benefit_finder/configuration
![image](https://github.com/GSA/px-bears-drupal/assets/88853916/1e513735-f79f-496c-ba6c-b5d60d179fd0)


