### PR TITLE
394 automate build json file

### DIFF
--- a/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_api/src/Controller/LifeEventController.php
@@ -60,7 +60,7 @@ class LifeEventController {
    *
    * @var string
    */
-  protected $mode;
+  public $mode;
 
   /**
    * Constructs a new LifeEventController object.

--- a/usagov_benefit_finder/modules/usagov_benefit_finder_api/usagov_benefit_finder_api.module
+++ b/usagov_benefit_finder/modules/usagov_benefit_finder_api/usagov_benefit_finder_api.module
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @file
+ * Provides usagov_benefit_finder_api.
+ */
+
+use Drupal\usagov_benefit_finder_api\Controller\LifeEventController;
+use Drupal\node\Entity\Node;
+
+/**
+ * Implements hook_node_update().
+ *
+ * @param Node $node
+ */
+function usagov_benefit_finder_api_node_update(Node $node) {
+  save_json_data($node);
+}
+
+/**
+ * Implements hook_node_insert().
+ *
+ * @param Node $node
+ */
+function usagov_benefit_finder_api_node_insert(Node $node) {
+  save_json_data($node);
+}
+
+/**
+ * Implements hook_node_delete().
+ *
+ * @param Node $node
+ */
+function usagov_benefit_finder_api_node_delete(Node $node) {
+  save_json_data($node);
+}
+
+/**
+ * Save Json data if node is benefit finder content.
+ *
+ * @param Node $node
+ */
+function save_json_data(Node $node) {
+  $config = \Drupal::config('usagov_benefit_finder.settings');
+  if ($config->get('automate_json_data_file_generating')) {
+    $content_types = [
+      'bears_agency',
+      'bears_criteria',
+      'bears_benefit',
+      'bears_life_event_form'
+    ];
+    if (in_array($node->getType(), $content_types)) {
+      $LifeEventController = new LifeEventController();
+      $result = \Drupal::service('database')
+        ->query('SELECT field_b_id_value FROM node__field_b_id WHERE bundle = :bundle', [':bundle' => 'bears_life_event_form'])
+        ->fetchAll();
+      foreach ($result as $record) {
+        $id = $record->field_b_id_value;
+        $LifeEventController->mode = "published";
+        $LifeEventController->saveJsonData($id);
+        $LifeEventController->mode = "draft";
+        $LifeEventController->saveJsonData($id);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## PR Summary

This work automates JSON data file generating when Benefit Finder content changes.

## Related Github Issue

- fixes #394 

## Detailed Testing steps

To test in sandbox or local:

Navigate to http://localhost/admin/config/usagov_benefit_finder/configuration
Check automate JSON data file generating.
[x] Automate JSON data file generation
![image](https://github.com/GSA/px-bears-drupal/assets/88853916/7d941c45-09e8-4495-86c8-7d9aecfca878)

Edit a Benefit Finder content, for example Benefit Finder criteria.
When saving the content change, the system automatically generates JSON data files for all life events in published and draft mode and in English and Spanish version.
