### PR TITLE
update to epoc comparison when compared to a specific date

### DIFF
--- a/benefit-finder/src/App/__tests__/__snapshots__/index.spec.js.snap
+++ b/benefit-finder/src/App/__tests__/__snapshots__/index.spec.js.snap
@@ -6171,18 +6171,13 @@ exports[`loads window query scenario 2 1`] = `
                           <p
                             class="key-eligibility-criteria-sub-heading"
                           >
-                            Met  2 of
+                            Met  1 of
             4
                           </p>
                         </h5>
                         <ul
                           class="key-eligibility-criteria-list"
                         >
-                          <li
-                            class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
-                          >
-                            Deceased died before 1978
-                          </li>
                           <li
                             class="usa-list usa-list--unstyled key-eligibility-criteria-list-item"
                           >
@@ -6201,6 +6196,11 @@ exports[`loads window query scenario 2 1`] = `
                         <ul
                           class="unmet-criteria-list"
                         >
+                          <li
+                            class="unmet-criteria-item"
+                          >
+                            Deceased died before 1978
+                          </li>
                           <li
                             class="unmet-criteria-item"
                           >

--- a/benefit-finder/src/shared/api/__tests__/apiCallsUtilsDateEligibility.spec.js
+++ b/benefit-finder/src/shared/api/__tests__/apiCallsUtilsDateEligibility.spec.js
@@ -66,28 +66,28 @@ const younger18 = {
 
 const conditionalsSpecificDate = [
   {
-    value: '>01-01-2023', // before 2023 (ie. 2022)
-    isSame: false,
-    isCloser: false,
-    isFurther: true,
-  },
-  {
-    value: '>=01-01-2023', // before or in 2023 (ie. 2022)
-    isSame: true,
-    isCloser: false,
-    isFurther: true,
-  },
-  {
-    value: '<01-01-2023', // after 2023 (ie. 2023-01-01)
+    value: '>01-01-2023', // after 2023 (ie. 2022)
     isSame: false,
     isCloser: true,
     isFurther: false,
+  },
+  {
+    value: '>=01-01-2023', // after or in 2023 (ie. 2022)
+    isSame: true,
+    isCloser: true,
+    isFurther: false,
+  },
+  {
+    value: '<01-01-2023', // before 2023 (ie. 2023-01-01)
+    isSame: false,
+    isCloser: false,
+    isFurther: true,
   },
   {
     value: '<=01-01-2023',
     isSame: true,
-    isCloser: true,
-    isFurther: false,
+    isCloser: false,
+    isFurther: true,
   },
   {
     value: '=01-01-2023',
@@ -138,14 +138,14 @@ const today = new window.Date(
 
 const conditionalsOthers = [
   {
-    value: '<01-01-1978', // after 1978
-    selectedValue: { year: 1977, month: 0, day: 1 },
-    eval: false,
-  },
-  {
-    value: '>01-01-1978', // before 1978
+    value: '<01-01-1978', // before 1978
     selectedValue: { year: 1977, month: 0, day: 1 },
     eval: true,
+  },
+  {
+    value: '>01-01-1978', // after 1978
+    selectedValue: { year: 1977, month: 0, day: 1 },
+    eval: false,
   },
   {
     // dynamic

--- a/benefit-finder/src/shared/api/apiCalls.js
+++ b/benefit-finder/src/shared/api/apiCalls.js
@@ -76,23 +76,38 @@ export const DateEligibility = ({ selectedValue, conditional }) => {
       )
     )
 
-    const diff = !pattern.test(text)
-      ? y.getTime() - x.getTime()
-      : y.getTime() - x.getTime()
+    if (pattern.test(text) === false) {
+      const diff = y.getTime() - x.getTime()
 
-    switch (operator.length && operator.join('')) {
-      case '>':
-        return diff > 0
-      case '>=':
-        return diff >= 0
-      case '<':
-        return diff < 0
-      case '<=':
-        return diff <= 0
-      case '=':
-        return +diff === 0
-      default:
-        return false
+      switch (operator.length && operator.join('')) {
+        case '>':
+          return diff > 0
+        case '>=':
+          return diff >= 0
+        case '<':
+          return diff < 0
+        case '<=':
+          return diff <= 0
+        case '=':
+          return +diff === 0
+        default:
+          return false
+      }
+    } else {
+      switch (operator.length && operator.join('')) {
+        case '>':
+          return x.getTime() > y.getTime()
+        case '>=':
+          return x.getTime() >= y.getTime()
+        case '<':
+          return x.getTime() < y.getTime()
+        case '<=':
+          return x.getTime() <= y.getTime()
+        case '=':
+          return +x.getTime() === +y.getTime()
+        default:
+          return false
+      }
     }
   }
   return isDateEligible(operator, conditionalDate, selectedDate)


### PR DESCRIPTION
## PR Summary

this updates date eligibility comparisons to epoch format

ie. 

// note: month: === monthIndex
// 0 - 11
const sameDate = { year: 2023, month: 0, day: 1 }
const closerDate = { year: 2023, month: 0, day: 2 } // younger
const furtherDate = { year: 2022, month: 11, day: 30 } // older

  {
    value: '<01-01-2023', // before 2023 (ie. 2023-01-01)
    isSame: false,
    isCloser: false,
    isFurther: true,
  },

## Related Github Issue

- fixes #695

## Detailed Testing steps

Link to testing steps in the issue or list them here:

- [ ] confirm the issues reported in this ticket are resolved https://github.com/GSA/px-bears-drupal/issues/695
